### PR TITLE
feat: add conversation memory system and UI improvements

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -17,11 +17,13 @@ import json
 import platform
 import logging
 import queue
+from collections import Counter
 from typing import Dict, List, Optional, Tuple, Any
 from datetime import datetime
 from pathlib import Path
 from dataclasses import dataclass, asdict, field
 from enum import Enum
+from uuid import uuid4
 
 # Web framework imports
 from flask import Flask, render_template, jsonify, request, send_file
@@ -181,10 +183,23 @@ class ConversationMessage:
     role: str
     content: str
     timestamp: str
+    message_id: str = ""
+    token_count: int = 0
     files: Optional[List[Dict]] = None
     metadata: Optional[Dict] = None
     terminal_output: Optional[str] = None
     usage_metadata: Optional[Dict] = None  # ⭐ 新增：直接保存 token 統計
+
+@dataclass
+class MemorySnapshot:
+    """長期記憶摘要結構"""
+    summary_id: str
+    created_at: str
+    summary_text: str
+    keywords: List[str] = field(default_factory=list)
+    related_messages: List[str] = field(default_factory=list)
+    token_count: int = 0
+    message_count: int = 0
 
 @dataclass
 class ProjectConversation:
@@ -194,6 +209,10 @@ class ProjectConversation:
     messages: List[ConversationMessage] = field(default_factory=list)
     created_at: str = ""
     updated_at: str = ""
+    short_term_memory: List[str] = field(default_factory=list)
+    long_term_memory: List[MemorySnapshot] = field(default_factory=list)
+    total_token_estimate: int = 0
+    last_memory_update: str = ""
 
 @dataclass
 class ProcessResult:
@@ -211,6 +230,183 @@ class ProcessResult:
     is_iteration: bool = False
     usage_metadata: Optional[Dict] = None
     terminal_output: str = ""
+    memory_state: Optional[Dict] = None
+    new_memory_snapshot: Optional[Dict] = None
+
+
+class MemoryManager:
+    """長短期記憶管理器"""
+
+    SHORT_TERM_LIMIT = 8
+    SUMMARY_MIN_MESSAGES = 6
+    TOKEN_SUMMARY_THRESHOLD = 6000
+    KEYWORD_LIMIT = 6
+
+    @classmethod
+    def estimate_tokens(cls, text: str) -> int:
+        if not text:
+            return 0
+        # 簡易估算: 假設平均 4 字元一個 token
+        return max(1, len(text) // 4)
+
+    @classmethod
+    def ensure_message_token(cls, message: ConversationMessage) -> int:
+        if message.token_count and message.token_count > 0:
+            return message.token_count
+
+        if message.usage_metadata and isinstance(message.usage_metadata, dict):
+            total = message.usage_metadata.get('total_token_count')
+            if isinstance(total, int) and total > 0:
+                message.token_count = total
+                return message.token_count
+
+        message.token_count = cls.estimate_tokens(message.content or "")
+        return message.token_count
+
+    @classmethod
+    def calculate_total_tokens(cls, conversation: ProjectConversation) -> int:
+        total = 0
+        for msg in conversation.messages:
+            total += cls.ensure_message_token(msg)
+        conversation.total_token_estimate = total
+        return total
+
+    @classmethod
+    def refresh_short_term(cls, conversation: ProjectConversation):
+        conversation.short_term_memory = [
+            msg.message_id for msg in conversation.messages[-cls.SHORT_TERM_LIMIT :]
+            if msg.message_id
+        ]
+
+    @classmethod
+    def extract_keywords(cls, text: str) -> List[str]:
+        if not text:
+            return []
+
+        tokens = re.findall(r"[\w\u4e00-\u9fa5]{2,}", text.lower())
+        if not tokens:
+            return []
+
+        counter = Counter(tokens)
+        common = [word for word, _ in counter.most_common(cls.KEYWORD_LIMIT * 2)]
+        # 去除過短或常見詞
+        filtered = []
+        stop_words = {"the", "and", "with", "from", "this", "that", "have", "project", "code", "file"}
+        for word in common:
+            if len(word.strip()) < 2:
+                continue
+            if word in stop_words:
+                continue
+            filtered.append(word)
+            if len(filtered) >= cls.KEYWORD_LIMIT:
+                break
+        return filtered
+
+    @classmethod
+    def build_snapshot(cls, messages: List[ConversationMessage], token_count: int) -> Optional[MemorySnapshot]:
+        if not messages:
+            return None
+
+        lines = []
+        combined_text_parts = []
+        for msg in messages:
+            role_label = "使用者" if msg.role == 'user' else "AI"
+            snippet = re.sub(r"\s+", " ", msg.content or "").strip()
+            if len(snippet) > 100:
+                snippet = snippet[:97] + "..."
+            lines.append(f"• {role_label}: {snippet}")
+            combined_text_parts.append(msg.content or "")
+
+        summary_text = "近期重點摘要:\n" + "\n".join(lines)
+        keywords = cls.extract_keywords(" ".join(combined_text_parts))
+
+        snapshot = MemorySnapshot(
+            summary_id=f"mem_{uuid4().hex}",
+            created_at=datetime.now().isoformat(),
+            summary_text=summary_text,
+            keywords=keywords,
+            related_messages=[msg.message_id for msg in messages if msg.message_id],
+            token_count=token_count,
+            message_count=len(messages)
+        )
+        return snapshot
+
+    @classmethod
+    def summarize_if_needed(cls, conversation: ProjectConversation) -> Optional[MemorySnapshot]:
+        summarized_ids = set()
+        for snapshot in conversation.long_term_memory:
+            summarized_ids.update(snapshot.related_messages)
+
+        unsummarized_messages = [
+            msg for msg in conversation.messages if msg.message_id and msg.message_id not in summarized_ids
+        ]
+
+        if not unsummarized_messages:
+            return None
+
+        unsummarized_token = sum(cls.ensure_message_token(msg) for msg in unsummarized_messages)
+
+        should_summarize = (
+            unsummarized_token >= cls.TOKEN_SUMMARY_THRESHOLD
+            or len(unsummarized_messages) >= cls.SUMMARY_MIN_MESSAGES
+        )
+
+        if not should_summarize:
+            return None
+
+        snapshot = cls.build_snapshot(unsummarized_messages, unsummarized_token)
+        if snapshot:
+            conversation.long_term_memory.append(snapshot)
+            conversation.last_memory_update = datetime.now().isoformat()
+        return snapshot
+
+    @classmethod
+    def serialize_snapshot(cls, snapshot: MemorySnapshot) -> Dict[str, Any]:
+        return {
+            'summary_id': snapshot.summary_id,
+            'created_at': snapshot.created_at,
+            'summary_text': snapshot.summary_text,
+            'keywords': snapshot.keywords,
+            'related_messages': snapshot.related_messages,
+            'token_count': snapshot.token_count,
+            'message_count': snapshot.message_count
+        }
+
+    @classmethod
+    def serialize_memory(cls, conversation: ProjectConversation) -> Dict[str, Any]:
+        message_map = {msg.message_id: msg for msg in conversation.messages if msg.message_id}
+        short_term_data = []
+        for msg_id in conversation.short_term_memory:
+            msg = message_map.get(msg_id)
+            if not msg:
+                continue
+            short_term_data.append({
+                'message_id': msg_id,
+                'role': msg.role,
+                'content_preview': (msg.content or '')[:120],
+                'timestamp': msg.timestamp,
+                'token_count': msg.token_count
+            })
+
+        return {
+            'short_term': short_term_data,
+            'long_term': [cls.serialize_snapshot(snapshot) for snapshot in conversation.long_term_memory],
+            'total_tokens': conversation.total_token_estimate,
+            'summary_threshold': cls.TOKEN_SUMMARY_THRESHOLD,
+            'short_term_limit': cls.SHORT_TERM_LIMIT,
+            'last_memory_update': conversation.last_memory_update
+        }
+
+    @classmethod
+    def update_conversation_memory(cls, conversation: ProjectConversation) -> Dict[str, Any]:
+        cls.calculate_total_tokens(conversation)
+        cls.refresh_short_term(conversation)
+        snapshot = cls.summarize_if_needed(conversation)
+        memory_state = cls.serialize_memory(conversation)
+        result: Dict[str, Any] = {'memory': memory_state}
+        if snapshot:
+            result['new_snapshot'] = cls.serialize_snapshot(snapshot)
+        return result
 
 # ============================================
 # JSON Schema 定義 - 繁體中文化
@@ -429,7 +625,7 @@ class ConversationManager:
     def load_conversation(project_dir: str) -> ProjectConversation:
         """載入專案對話歷史 - 正確處理 usage_metadata"""
         conv_file = ConversationManager.get_conversation_file(project_dir)
-        
+
         if not conv_file.exists():
             project_name = Path(project_dir).name
             conv = ProjectConversation(
@@ -439,35 +635,72 @@ class ConversationManager:
                 updated_at=datetime.now().isoformat()
             )
             return conv
-        
+
         try:
             with open(conv_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
-                messages = []
-                for msg_data in data.get('messages', []):
-                    # ⭐ 關鍵修復：正確處理 usage_metadata
-                    usage_metadata = msg_data.get('usage_metadata')
-                    if not usage_metadata and msg_data.get('metadata'):
-                        # 向後兼容：從 metadata 中提取 usage_metadata
-                        usage_metadata = msg_data['metadata'].get('usage_metadata')
-                    
-                    messages.append(ConversationMessage(
-                        role=msg_data['role'],
-                        content=msg_data['content'],
-                        timestamp=msg_data['timestamp'],
-                        files=msg_data.get('files'),
-                        metadata=msg_data.get('metadata'),
-                        terminal_output=msg_data.get('terminal_output'),
-                        usage_metadata=usage_metadata  # ⭐ 直接保存
-                    ))
-                
-                return ProjectConversation(
-                    project_dir=data['project_dir'],
-                    project_name=data['project_name'],
-                    messages=messages,
-                    created_at=data.get('created_at', ''),
-                    updated_at=data.get('updated_at', '')
+
+            messages: List[ConversationMessage] = []
+            for index, msg_data in enumerate(data.get('messages', [])):
+                usage_metadata = msg_data.get('usage_metadata')
+                if not usage_metadata and msg_data.get('metadata'):
+                    usage_metadata = msg_data['metadata'].get('usage_metadata')
+
+                message_id = msg_data.get('message_id') or f"msg_{index + 1}_{uuid4().hex[:8]}"
+                timestamp = msg_data.get('timestamp') or datetime.now().isoformat()
+                message = ConversationMessage(
+                    role=msg_data.get('role', 'assistant'),
+                    content=msg_data.get('content', ''),
+                    timestamp=timestamp,
+                    message_id=message_id,
+                    token_count=msg_data.get('token_count', 0),
+                    files=msg_data.get('files'),
+                    metadata=msg_data.get('metadata'),
+                    terminal_output=msg_data.get('terminal_output'),
+                    usage_metadata=usage_metadata
                 )
+                MemoryManager.ensure_message_token(message)
+                messages.append(message)
+
+            long_term_memory: List[MemorySnapshot] = []
+            for snapshot_data in data.get('long_term_memory', []):
+                try:
+                    long_term_memory.append(MemorySnapshot(
+                        summary_id=snapshot_data.get('summary_id', f"mem_{uuid4().hex}"),
+                        created_at=snapshot_data.get('created_at', datetime.now().isoformat()),
+                        summary_text=snapshot_data.get('summary_text', ''),
+                        keywords=snapshot_data.get('keywords', []),
+                        related_messages=snapshot_data.get('related_messages', []),
+                        token_count=snapshot_data.get('token_count', 0),
+                        message_count=snapshot_data.get('message_count', 0)
+                    ))
+                except Exception as err:
+                    logger.warning(f"載入長期記憶摘要失敗: {err}")
+
+            conversation = ProjectConversation(
+                project_dir=data.get('project_dir', project_dir),
+                project_name=data.get('project_name', Path(project_dir).name),
+                messages=messages,
+                created_at=data.get('created_at', ''),
+                updated_at=data.get('updated_at', ''),
+                short_term_memory=data.get('short_term_memory', []),
+                long_term_memory=long_term_memory,
+                total_token_estimate=data.get('total_token_estimate', 0),
+                last_memory_update=data.get('last_memory_update', data.get('updated_at', ''))
+            )
+
+            if not conversation.project_name:
+                conversation.project_name = Path(project_dir).name
+
+            MemoryManager.calculate_total_tokens(conversation)
+
+            if not conversation.short_term_memory:
+                MemoryManager.refresh_short_term(conversation)
+
+            if not conversation.last_memory_update:
+                conversation.last_memory_update = conversation.updated_at or datetime.now().isoformat()
+
+            return conversation
         except Exception as e:
             logger.error(f"載入對話歷史失敗: {e}")
             return ProjectConversation(
@@ -483,32 +716,54 @@ class ConversationManager:
         try:
             conv_file = ConversationManager.get_conversation_file(conversation.project_dir)
             conversation.updated_at = datetime.now().isoformat()
-            
-            # ⭐ 關鍵修復：使用自定義序列化保留 usage_metadata
+
+            MemoryManager.calculate_total_tokens(conversation)
+            MemoryManager.refresh_short_term(conversation)
+
+            if not conversation.created_at:
+                if conversation.messages:
+                    conversation.created_at = conversation.messages[0].timestamp
+                else:
+                    conversation.created_at = datetime.now().isoformat()
+
             messages_data = []
             for msg in conversation.messages:
+                MemoryManager.ensure_message_token(msg)
                 msg_dict = {
                     'role': msg.role,
                     'content': msg.content,
                     'timestamp': msg.timestamp,
+                    'message_id': msg.message_id,
+                    'token_count': msg.token_count,
                     'files': msg.files,
                     'metadata': msg.metadata,
                     'terminal_output': msg.terminal_output,
-                    'usage_metadata': msg.usage_metadata  # ⭐ 直接保存
+                    'usage_metadata': msg.usage_metadata
                 }
                 messages_data.append(msg_dict)
-            
+
+            long_term_data: List[Dict[str, Any]] = []
+            for snapshot in conversation.long_term_memory:
+                if isinstance(snapshot, MemorySnapshot):
+                    long_term_data.append(asdict(snapshot))
+                elif isinstance(snapshot, dict):
+                    long_term_data.append(snapshot)
+
             data = {
                 'project_dir': conversation.project_dir,
                 'project_name': conversation.project_name,
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'short_term_memory': conversation.short_term_memory,
+                'long_term_memory': long_term_data,
+                'total_token_estimate': conversation.total_token_estimate,
+                'last_memory_update': conversation.last_memory_update
             }
-            
+
             with open(conv_file, 'w', encoding='utf-8') as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
-            
+
             logger.info(f"對話歷史已儲存: {conversation.project_name}")
             return True
         except Exception as e:
@@ -516,24 +771,39 @@ class ConversationManager:
             return False
     
     @staticmethod
-    def add_message(project_dir: str, role: str, content: str, files: Optional[List[Dict]] = None, 
+    def add_message(project_dir: str, role: str, content: str, files: Optional[List[Dict]] = None,
                    metadata: Optional[Dict] = None, terminal_output: Optional[str] = None,
                    usage_metadata: Optional[Dict] = None):  # ⭐ 新增參數
         """添加消息到對話歷史 - 支持 usage_metadata"""
         conversation = ConversationManager.load_conversation(project_dir)
-        
+
+        message_id = f"msg_{len(conversation.messages) + 1}_{uuid4().hex[:8]}"
         message = ConversationMessage(
             role=role,
             content=content,
             timestamp=datetime.now().isoformat(),
+            message_id=message_id,
+            token_count=0,
             files=files,
             metadata=metadata,
             terminal_output=terminal_output,
-            usage_metadata=usage_metadata  # ⭐ 直接保存
+            usage_metadata=usage_metadata
         )
-        
+
+        MemoryManager.ensure_message_token(message)
         conversation.messages.append(message)
+
+        memory_update = MemoryManager.update_conversation_memory(conversation)
         ConversationManager.save_conversation(conversation)
+
+        return {
+            'message': {
+                'message_id': message.message_id,
+                'role': message.role,
+                'timestamp': message.timestamp
+            },
+            **memory_update
+        }
     
     @staticmethod
     def delete_conversation_file(project_dir: str) -> bool:
@@ -1685,13 +1955,18 @@ class ProcessManager:
                     result.terminal_output = terminal_output
             
             # ⭐ 修復:在正確的時機保存用戶消息
-            ConversationManager.add_message(
+            user_memory_update = ConversationManager.add_message(
                 folder_path,
                 'user',
                 prompt,
                 files=[{'name': f.get('name'), 'type': f.get('type')} for f in (files or [])],
                 terminal_output=terminal_output
             )
+
+            if user_memory_update:
+                result.memory_state = user_memory_update.get('memory', result.memory_state)
+                if user_memory_update.get('new_snapshot'):
+                    result.new_memory_snapshot = user_memory_update['new_snapshot']
             
             if is_iteration and attach_screenshot:
                 project_info = ProjectManager.load_project_info(folder_path)
@@ -1820,13 +2095,18 @@ class ProcessManager:
                     result.output += "\n=== 🔍 檢測到程式碼區塊 ===\n您可以手動複製下方 AI 回應中的程式碼。"
                 
                 # ⭐ 修復:使用正確的路徑保存錯誤消息
-                ConversationManager.add_message(
+                error_memory_update = ConversationManager.add_message(
                     folder_path,
                     'assistant',
                     result.output,
                     metadata={'error': True, 'error_type': 'parse_error'}
                 )
-                
+
+                if error_memory_update:
+                    result.memory_state = error_memory_update.get('memory', result.memory_state)
+                    if error_memory_update.get('new_snapshot'):
+                        result.new_memory_snapshot = error_memory_update['new_snapshot']
+
                 return result
             
             if is_iteration:
@@ -2049,7 +2329,7 @@ class ProcessManager:
             result.success = True
             
             # ⭐ 關鍵修復:使用最終路徑和正確的 usage_metadata 保存AI回應
-            ConversationManager.add_message(
+            assistant_memory_update = ConversationManager.add_message(
                 final_project_dir,  # ✅ 使用最終專案路徑
                 'assistant',
                 result.output,
@@ -2060,6 +2340,11 @@ class ProcessManager:
                 terminal_output=result.terminal_output,
                 usage_metadata=usage_metadata  # ⭐ 直接傳遞 usage_metadata
             )
+
+            if assistant_memory_update:
+                result.memory_state = assistant_memory_update.get('memory', result.memory_state)
+                if assistant_memory_update.get('new_snapshot'):
+                    result.new_memory_snapshot = assistant_memory_update['new_snapshot']
             
         except Exception as e:
             result.error = str(e)
@@ -2071,12 +2356,17 @@ class ProcessManager:
                 result.ai_response = "無法獲取 AI 回應"
             
             # 錯誤情況下也保存消息
-            ConversationManager.add_message(
+            failure_memory_update = ConversationManager.add_message(
                 folder_path,
                 'assistant',
                 f"執行失敗: {result.error}",
                 metadata={'error': True, 'error_type': 'execution_error'}
             )
+
+            if failure_memory_update:
+                result.memory_state = failure_memory_update.get('memory', result.memory_state)
+                if failure_memory_update.get('new_snapshot'):
+                    result.new_memory_snapshot = failure_memory_update['new_snapshot']
         
         return result
 
@@ -2173,6 +2463,8 @@ def load_project():
                 'role': msg.role,
                 'content': msg.content,
                 'timestamp': msg.timestamp,
+                'message_id': msg.message_id,
+                'token_count': msg.token_count,
                 'files': msg.files,
                 'metadata': msg.metadata,
                 'terminal_output': msg.terminal_output,
@@ -2189,7 +2481,8 @@ def load_project():
             'conversation': {
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'memory': MemoryManager.serialize_memory(conversation)
             }
         })
         
@@ -2216,6 +2509,8 @@ def get_conversation(project_dir):
                 'role': msg.role,
                 'content': msg.content,
                 'timestamp': msg.timestamp,
+                'message_id': msg.message_id,
+                'token_count': msg.token_count,
                 'files': msg.files,
                 'metadata': msg.metadata,
                 'terminal_output': msg.terminal_output,
@@ -2229,7 +2524,8 @@ def get_conversation(project_dir):
                 'project_name': conversation.project_name,
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'memory': MemoryManager.serialize_memory(conversation)
             }
         })
     except Exception as e:
@@ -2324,7 +2620,9 @@ def run_process():
             'screenshots': result.screenshots,
             'is_iteration': result.is_iteration,
             'usage_metadata': result.usage_metadata,
-            'terminal_output': result.terminal_output
+            'terminal_output': result.terminal_output,
+            'memory': result.memory_state,
+            'new_memory_snapshot': result.new_memory_snapshot
         }
         
         if result.project_data:

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -13,6 +13,8 @@ let allProjects = [];
 let modelConfig = null;
 let sidebarCollapsed = false;
 let MODEL_LIMITS = {};
+let conversationMemory = null;
+let latestMemorySnapshot = null;
 
 // ============================================
 // Loading Overlay 控制 - 修復版
@@ -43,6 +45,7 @@ function hideLoading() {
 // 初始化
 // ============================================
 window.addEventListener('DOMContentLoaded', () => {
+    clearMemoryPanel();
     loadConfig();
     loadSettings();
     loadProjectsList();
@@ -74,6 +77,15 @@ window.addEventListener('DOMContentLoaded', () => {
                 e.target.value = '';
             } finally {
                 hideLoading();
+            }
+        });
+    }
+
+    const memoryWindow = document.getElementById('memoryWindow');
+    if (memoryWindow) {
+        memoryWindow.addEventListener('click', (event) => {
+            if (event.target === memoryWindow) {
+                closeMemoryWindow();
             }
         });
     }
@@ -167,7 +179,7 @@ function updateAttachedFilesDisplay() {
     const section = document.getElementById('attachedFilesSection');
     const countBadge = document.getElementById('attachedFilesCount');
     const filesList = document.getElementById('attachedFilesList');
-    
+
     if (!section || !countBadge || !filesList) return;
     
     if (uploadedFiles.length === 0) {
@@ -315,7 +327,7 @@ function handleKeyDown(event) {
 async function handleSubmit() {
     const input = document.getElementById('mainInput');
     const prompt = input?.value.trim();
-    
+
     if (!prompt) return;
 
     if (!currentProjectDir) {
@@ -327,7 +339,15 @@ async function handleSubmit() {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
 
-    addMessage('user', prompt);
+    const attachmentsForMessage = uploadedFiles.map(file => ({
+        name: file.name,
+        type: file.type,
+        size: file.size
+    }));
+
+    addMessage('user', prompt, null, null, attachmentsForMessage, {
+        timestamp: new Date().toISOString()
+    });
 
     input.value = '';
     updateSubmitButton();
@@ -355,21 +375,35 @@ async function handleSubmit() {
         const result = await response.json();
 
         if (result.success) {
-            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output);
-            
+            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output, null, {
+                timestamp: new Date().toISOString()
+            });
+
+            if ('memory' in result) {
+                if (result.memory) {
+                    updateMemoryPanel(result.memory);
+                } else {
+                    clearMemoryPanel();
+                }
+            }
+
+            if (result.new_memory_snapshot) {
+                showMemoryWindow(result.new_memory_snapshot);
+            }
+
             if (result.project) {
                 currentProject = result.project;
                 if (result.ai_response_json) {
                     currentProject.json_data = result.ai_response_json;
                     displayProjectStructure(result.ai_response_json.files);
                 }
-                
+
                 document.getElementById('currentProjectName').textContent = currentProject.name;
-                
+
                 if (!isIterationMode) {
                     const newProjectDir = currentProjectDir + '/' + currentProject.name;
                     currentProjectDir = newProjectDir;
-                    
+
                     isIterationMode = true;
                     const badge = document.getElementById('projectModeBadge');
                     if (badge) {
@@ -380,32 +414,49 @@ async function handleSubmit() {
             }
 
             showNotification(result.is_iteration ? '專案迭代成功!' : '專案創建成功!', 'success');
-            
+
             loadProjectsList();
             uploadedFiles = [];
             updateFilesPreview();
             updateAttachedFilesDisplay();
         } else {
-            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`);
+            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`, null, result.terminal_output, null, {
+                timestamp: new Date().toISOString()
+            });
             showNotification(`執行失敗：${result.error}`, 'error');
+
+            if ('memory' in result) {
+                if (result.memory) {
+                    updateMemoryPanel(result.memory);
+                } else {
+                    clearMemoryPanel();
+                }
+            }
+
+            loadProjectsList();
         }
     } catch (error) {
-        addMessage('assistant', `✕ 連接錯誤：${error}`);
+        addMessage('assistant', `✕ 連接錯誤：${error}`, null, null, null, {
+            timestamp: new Date().toISOString()
+        });
         showNotification(`連接錯誤：${error}`, 'error');
     } finally {
         hideLoading();
     }
 }
 
-function addMessage(role, content, usageMetadata = null, terminalOutput = null) {
+function addMessage(role, content, usageMetadata = null, terminalOutput = null, files = null, options = {}) {
     const container = document.getElementById('resultsContainer');
     if (!container) return;
-    
+
     const message = document.createElement('div');
     message.className = `result-message ${role} selectable`;
 
     const header = document.createElement('div');
     header.className = 'message-header';
+
+    const headerMain = document.createElement('div');
+    headerMain.className = 'message-header-main';
 
     const avatar = document.createElement('div');
     avatar.className = `avatar ${role}`;
@@ -415,29 +466,49 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
     roleLabel.textContent = role === 'user' ? '您' : 'AI 助手';
     roleLabel.style.fontWeight = '500';
 
-    header.appendChild(avatar);
-    header.appendChild(roleLabel);
+    headerMain.appendChild(avatar);
+    headerMain.appendChild(roleLabel);
+    header.appendChild(headerMain);
+
+    const timestampValue = options.timestamp || new Date().toISOString();
+    if (timestampValue) {
+        const timeLabel = document.createElement('span');
+        timeLabel.className = 'message-timestamp';
+        timeLabel.textContent = formatTimestamp(timestampValue);
+        header.appendChild(timeLabel);
+    }
 
     const messageContent = document.createElement('div');
     messageContent.className = 'message-content selectable';
-    messageContent.textContent = content;
+    messageContent.textContent = content || '';
 
     message.appendChild(header);
     message.appendChild(messageContent);
-    
-    // ✅ Terminal輸出只顯示在用戶消息中
-    if (role === 'user' && terminalOutput && terminalOutput.trim()) {
+
+    const attachmentSection = renderAttachments(files);
+    if (attachmentSection) {
+        message.appendChild(attachmentSection);
+    }
+
+    if (terminalOutput && terminalOutput.trim()) {
         const terminalSection = document.createElement('div');
         terminalSection.className = 'terminal-output-section';
-        terminalSection.innerHTML = `
-            <div class="terminal-header">
-                <span class="terminal-title">Terminal 輸出</span>
-            </div>
-            <div class="terminal-body selectable">${terminalOutput}</div>
-        `;
+        const terminalHeader = document.createElement('div');
+        terminalHeader.className = 'terminal-header';
+        const terminalTitle = document.createElement('span');
+        terminalTitle.className = 'terminal-title';
+        terminalTitle.textContent = role === 'user' ? 'Terminal 輸出 (提交時)' : 'Terminal 輸出';
+        terminalHeader.appendChild(terminalTitle);
+
+        const terminalBody = document.createElement('div');
+        terminalBody.className = 'terminal-body selectable';
+        terminalBody.textContent = terminalOutput;
+
+        terminalSection.appendChild(terminalHeader);
+        terminalSection.appendChild(terminalBody);
         message.appendChild(terminalSection);
     }
-    
+
     // Token使用統計只顯示在AI回應中
     if (role === 'assistant' && usageMetadata && typeof usageMetadata === 'object') {
         const tokenUsage = document.createElement('div');
@@ -490,7 +561,7 @@ async function createNewProject() {
         if (result.success && result.path) {
             currentProjectDir = result.path;
             isIterationMode = false;
-            
+
             document.getElementById('currentProjectDisplay').style.display = 'block';
             document.getElementById('currentProjectName').textContent = '新專案';
             const badge = document.getElementById('projectModeBadge');
@@ -513,7 +584,8 @@ async function createNewProject() {
             document.getElementById('emptyState').style.display = 'none';
             document.getElementById('resultsContainer').style.display = 'block';
             document.getElementById('resultsContainer').innerHTML = '';
-            
+            clearMemoryPanel();
+
             showNotification('已選擇專案資料夾', 'success');
             document.getElementById('mainInput')?.focus();
         } else {
@@ -535,13 +607,15 @@ async function selectExistingFolder() {
         if (result.success && result.path) {
             currentProjectDir = result.path;
             isIterationMode = true;
-            
+
             uploadedFiles = [];
             updateFilesPreview();
             updateAttachedFilesDisplay();
-            
+
+            clearMemoryPanel();
+
             const loadResult = await loadExistingProject(result.path);
-            
+
             if (loadResult) {
                 document.getElementById('currentProjectDisplay').style.display = 'block';
                 document.getElementById('currentProjectName').textContent = currentProject.name;
@@ -715,13 +789,21 @@ async function loadExistingProject(projectDir) {
                 const container = document.getElementById('resultsContainer');
                 if (container) {
                     container.innerHTML = '';
-                    
+
                     for (const msg of result.conversation.messages) {
-                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output);
+                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output, msg.files, {
+                            timestamp: msg.timestamp
+                        });
                     }
                 }
             }
-            
+
+            if (result.conversation.memory) {
+                updateMemoryPanel(result.conversation.memory);
+            } else {
+                clearMemoryPanel();
+            }
+
             return true;
         } else {
             return false;
@@ -831,7 +913,8 @@ function resetToHome() {
     document.getElementById('resultsContainer').innerHTML = '';
     document.getElementById('projectStructureSection').style.display = 'none';
     document.getElementById('homeBtn').style.display = 'none';
-    
+    clearMemoryPanel();
+
     document.querySelectorAll('.project-item').forEach(item => {
         item.classList.remove('active');
     });
@@ -1211,4 +1294,279 @@ function showNotification(message, type = 'info') {
         toast.style.animation = 'slideIn 0.3s ease reverse';
         setTimeout(() => toast.remove(), 300);
     }, 5000);
+}
+
+// ============================================
+// 共用工具函式
+// ============================================
+
+function escapeHtml(text) {
+    if (typeof text !== 'string') return '';
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+function formatTimestamp(timestamp) {
+    if (!timestamp) return '';
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+        return timestamp;
+    }
+    return date.toLocaleString('zh-TW', {
+        hour12: false,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit'
+    });
+}
+
+function createAttachmentIcon(typeOrName) {
+    const value = (typeOrName || '').toLowerCase();
+    if (!value) return '📎';
+    if (value.includes('image') || value.match(/\.(png|jpg|jpeg|gif|svg)$/)) return '🖼️';
+    if (value.includes('pdf') || value.endsWith('.pdf')) return '📄';
+    if (value.includes('zip') || value.includes('rar') || value.endsWith('.zip')) return '🗜️';
+    if (value.includes('code') || value.match(/\.(py|js|ts|html|css|json|sql|java|cpp|md)$/)) return '💻';
+    if (value.includes('text') || value.endsWith('.txt')) return '📝';
+    return '📎';
+}
+
+function renderAttachments(files) {
+    if (!Array.isArray(files) || files.length === 0) {
+        return null;
+    }
+
+    const container = document.createElement('div');
+    container.className = 'attachment-section';
+
+    const title = document.createElement('div');
+    title.className = 'attachment-title';
+    title.textContent = `附加檔案 (${files.length})`;
+    container.appendChild(title);
+
+    const list = document.createElement('div');
+    list.className = 'attachment-list';
+
+    files.forEach(file => {
+        if (!file) return;
+        const item = document.createElement('div');
+        item.className = 'attachment-item';
+
+        const icon = document.createElement('span');
+        icon.className = 'attachment-icon';
+        icon.textContent = createAttachmentIcon(file.type || file.name || file.mime);
+
+        const name = document.createElement('span');
+        name.className = 'attachment-name';
+        name.textContent = file.name || '未命名檔案';
+
+        item.appendChild(icon);
+        item.appendChild(name);
+
+        if (file.size) {
+            const size = document.createElement('span');
+            size.className = 'attachment-size';
+            const kb = Math.max(1, Math.round(file.size / 1024));
+            size.textContent = `${kb} KB`;
+            item.appendChild(size);
+        }
+
+        list.appendChild(item);
+    });
+
+    container.appendChild(list);
+    return container;
+}
+
+function clearMemoryPanel() {
+    conversationMemory = null;
+    latestMemorySnapshot = null;
+
+    const panel = document.getElementById('memoryPanel');
+    const longList = document.getElementById('longTermMemoryList');
+    const shortList = document.getElementById('shortTermMemoryList');
+    const stats = document.getElementById('memoryStats');
+
+    if (panel) {
+        panel.style.display = 'none';
+        panel.classList.remove('memory-alert');
+    }
+    if (stats) {
+        stats.textContent = '';
+    }
+    if (longList) {
+        longList.innerHTML = '';
+        longList.classList.add('empty');
+        longList.textContent = '尚無長期記憶摘要';
+    }
+    if (shortList) {
+        shortList.innerHTML = '';
+        shortList.classList.add('empty');
+        shortList.textContent = '尚無短期記憶';
+    }
+}
+
+function updateMemoryPanel(memory) {
+    const panel = document.getElementById('memoryPanel');
+    const stats = document.getElementById('memoryStats');
+    const longList = document.getElementById('longTermMemoryList');
+    const shortList = document.getElementById('shortTermMemoryList');
+
+    if (!panel || !stats || !longList || !shortList) return;
+
+    if (!memory) {
+        clearMemoryPanel();
+        return;
+    }
+
+    conversationMemory = memory;
+
+    panel.style.display = 'block';
+    if (memory.total_tokens >= memory.summary_threshold) {
+        panel.classList.add('memory-alert');
+    } else {
+        panel.classList.remove('memory-alert');
+    }
+
+    stats.textContent = `累積 Token 約 ${memory.total_tokens || 0} / 閾值 ${memory.summary_threshold || 0}`;
+
+    longList.innerHTML = '';
+    shortList.innerHTML = '';
+
+    if (memory.long_term && memory.long_term.length) {
+        longList.classList.remove('empty');
+        memory.long_term.forEach((snapshot, index) => {
+            const item = document.createElement('div');
+            item.className = 'memory-item';
+
+            const header = document.createElement('div');
+            header.className = 'memory-item-header';
+
+            const title = document.createElement('span');
+            title.className = 'memory-item-title';
+            title.textContent = `摘要 #${index + 1}`;
+
+            const meta = document.createElement('span');
+            meta.className = 'memory-item-meta';
+            meta.textContent = formatTimestamp(snapshot.created_at);
+
+            header.appendChild(title);
+            header.appendChild(meta);
+
+            const body = document.createElement('div');
+            body.className = 'memory-item-body';
+            body.textContent = snapshot.summary_text || '';
+
+            const footer = document.createElement('div');
+            footer.className = 'memory-item-footer';
+            footer.textContent = `覆蓋 ${snapshot.message_count || 0} 則訊息 / 約 ${snapshot.token_count || 0} tokens`;
+
+            item.appendChild(header);
+            item.appendChild(body);
+            item.appendChild(footer);
+
+            if (snapshot.keywords && snapshot.keywords.length) {
+                const keywordWrap = document.createElement('div');
+                keywordWrap.className = 'memory-keywords';
+                snapshot.keywords.forEach(keyword => {
+                    const tag = document.createElement('span');
+                    tag.className = 'memory-keyword';
+                    tag.textContent = keyword;
+                    keywordWrap.appendChild(tag);
+                });
+                item.appendChild(keywordWrap);
+            }
+
+            longList.appendChild(item);
+        });
+    } else {
+        longList.classList.add('empty');
+        longList.textContent = '尚無長期記憶摘要';
+    }
+
+    if (memory.short_term && memory.short_term.length) {
+        shortList.classList.remove('empty');
+        memory.short_term.forEach(msg => {
+            const item = document.createElement('div');
+            item.className = 'short-term-item';
+
+            const role = document.createElement('div');
+            role.className = 'short-term-item-role';
+            role.textContent = msg.role === 'user' ? '使用者' : 'AI';
+
+            const content = document.createElement('div');
+            content.className = 'short-term-item-content';
+            content.textContent = (msg.content_preview || '').trim();
+
+            const time = document.createElement('div');
+            time.className = 'short-term-item-time';
+            time.textContent = formatTimestamp(msg.timestamp);
+
+            item.appendChild(role);
+            item.appendChild(content);
+            item.appendChild(time);
+
+            if (msg.token_count) {
+                const tokenInfo = document.createElement('div');
+                tokenInfo.className = 'short-term-item-tokens';
+                tokenInfo.textContent = `約 ${msg.token_count} tokens`;
+                item.appendChild(tokenInfo);
+            }
+
+            shortList.appendChild(item);
+        });
+    } else {
+        shortList.classList.add('empty');
+        shortList.textContent = '尚無短期記憶';
+    }
+}
+
+function showMemoryWindow(snapshot) {
+    const windowEl = document.getElementById('memoryWindow');
+    const summaryEl = document.getElementById('memoryWindowSummary');
+    const keywordsEl = document.getElementById('memoryWindowKeywords');
+    const tokensEl = document.getElementById('memoryWindowTokens');
+
+    if (!snapshot || !windowEl || !summaryEl || !keywordsEl || !tokensEl) return;
+
+    if (latestMemorySnapshot && latestMemorySnapshot.summary_id === snapshot.summary_id) {
+        return;
+    }
+
+    latestMemorySnapshot = snapshot;
+
+    summaryEl.textContent = snapshot.summary_text || '';
+    tokensEl.textContent = `本次摘要覆蓋約 ${snapshot.token_count || 0} tokens，包含 ${snapshot.message_count || 0} 則訊息。`;
+
+    keywordsEl.innerHTML = '';
+    if (snapshot.keywords && snapshot.keywords.length) {
+        snapshot.keywords.forEach(keyword => {
+            const tag = document.createElement('span');
+            tag.className = 'memory-window-keyword';
+            tag.textContent = keyword;
+            keywordsEl.appendChild(tag);
+        });
+    } else {
+        const placeholder = document.createElement('span');
+        placeholder.className = 'memory-window-keyword';
+        placeholder.textContent = '無特定關鍵字';
+        keywordsEl.appendChild(placeholder);
+    }
+
+    windowEl.classList.add('active');
+    showNotification('已建立新的長期記憶摘要', 'info');
+}
+
+function closeMemoryWindow() {
+    const windowEl = document.getElementById('memoryWindow');
+    if (windowEl) {
+        windowEl.classList.remove('active');
+    }
 }

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -835,8 +835,21 @@ body {
 .message-header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 10px;
     margin-bottom: 10px;
+}
+
+.message-header-main {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.message-timestamp {
+    font-size: 11px;
+    color: var(--text-tertiary);
+    white-space: nowrap;
 }
 
 .avatar {
@@ -925,6 +938,306 @@ body {
     line-height: 1.4;
     white-space: pre-wrap;
     word-wrap: break-word;
+}
+
+/* =================================== */
+/* 附件區塊 */
+/* =================================== */
+.attachment-section {
+    margin-top: 10px;
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    background: var(--bg-primary);
+    padding: 10px 12px;
+}
+
+.attachment-title {
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.attachment-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.attachment-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-light);
+    font-size: 12px;
+    color: var(--text-primary);
+}
+
+.attachment-icon {
+    font-size: 14px;
+}
+
+.attachment-name {
+    font-weight: 500;
+}
+
+.attachment-size {
+    font-size: 11px;
+    color: var(--text-tertiary);
+}
+
+/* =================================== */
+/* 長短期記憶面板 */
+/* =================================== */
+.memory-panel {
+    max-width: 900px;
+    margin: 0 auto 20px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-light);
+    border-radius: 14px;
+    padding: 16px 20px;
+    display: none;
+    box-shadow: var(--shadow-sm);
+}
+
+.memory-panel.memory-alert {
+    border-color: #f97316;
+    box-shadow: 0 6px 20px rgba(249, 115, 22, 0.15);
+}
+
+.memory-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 16px;
+}
+
+.memory-header h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 4px;
+}
+
+.memory-subtitle,
+#memoryStats {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-body {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+}
+
+.memory-column h4 {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+    font-weight: 600;
+}
+
+.memory-list {
+    background: var(--bg-primary);
+    border: 1px dashed var(--border-light);
+    border-radius: 10px;
+    padding: 12px;
+    min-height: 140px;
+    max-height: 260px;
+    overflow-y: auto;
+}
+
+.memory-list.empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    color: var(--text-tertiary);
+    font-style: italic;
+}
+
+.memory-item {
+    border-bottom: 1px solid var(--border-light);
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}
+
+.memory-item:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+
+.memory-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+}
+
+.memory-item-body {
+    font-size: 13px;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    line-height: 1.5;
+}
+
+.memory-item-footer {
+    margin-top: 6px;
+    font-size: 11px;
+    color: var(--text-tertiary);
+}
+
+.memory-keywords {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 8px;
+}
+
+.memory-keyword {
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    padding: 3px 8px;
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.short-term-item {
+    background: var(--bg-secondary);
+    border-radius: 10px;
+    border: 1px solid var(--border-light);
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+.short-term-item:last-child {
+    margin-bottom: 0;
+}
+
+.short-term-item-role {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 4px;
+}
+
+.short-term-item-content {
+    font-size: 13px;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    line-height: 1.5;
+}
+
+.short-term-item-time {
+    font-size: 11px;
+    color: var(--text-tertiary);
+    margin-top: 6px;
+}
+
+.short-term-item-tokens {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
+
+/* =================================== */
+/* 長期記憶視窗 */
+/* =================================== */
+.memory-window {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 20000;
+    padding: 24px;
+}
+
+.memory-window.active {
+    display: flex;
+}
+
+.memory-window-content {
+    background: var(--bg-primary);
+    border-radius: 16px;
+    max-width: 520px;
+    width: 100%;
+    border: 1px solid var(--border-light);
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+}
+
+.memory-window-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-light);
+    font-weight: 600;
+    font-size: 15px;
+}
+
+.close-memory-window {
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    color: var(--text-secondary);
+}
+
+.close-memory-window:hover {
+    color: var(--text-primary);
+}
+
+.memory-window-body {
+    padding: 20px;
+    max-height: 70vh;
+    overflow-y: auto;
+}
+
+.memory-window-tokens {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+}
+
+.memory-window-summary {
+    font-size: 13px;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    line-height: 1.6;
+}
+
+.memory-window-keywords {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.memory-window-keyword {
+    background: var(--bg-secondary);
+    border-radius: 14px;
+    padding: 4px 10px;
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 900px) {
+    .memory-body {
+        grid-template-columns: 1fr;
+    }
 }
 
 /* =================================== */

--- a/vscode_controller_project3-1/templates/index.html
+++ b/vscode_controller_project3-1/templates/index.html
@@ -179,6 +179,25 @@
                 </div>
             </div>
 
+            <div class="memory-panel" id="memoryPanel">
+                <div class="memory-header">
+                    <div>
+                        <h3>長短期記憶</h3>
+                        <div class="memory-subtitle" id="memoryStats"></div>
+                    </div>
+                </div>
+                <div class="memory-body">
+                    <div class="memory-column">
+                        <h4>長期記憶摘要</h4>
+                        <div class="memory-list empty" id="longTermMemoryList">尚無長期記憶摘要</div>
+                    </div>
+                    <div class="memory-column">
+                        <h4>短期上下文</h4>
+                        <div class="memory-list empty" id="shortTermMemoryList">尚無短期記憶</div>
+                    </div>
+                </div>
+            </div>
+
             <div class="results-container" id="resultsContainer" style="display: none;"></div>
         </div>
 
@@ -437,5 +456,19 @@
     </div>
 
     <script src="static/app.js"></script>
+
+    <div class="memory-window" id="memoryWindow">
+        <div class="memory-window-content">
+            <div class="memory-window-header">
+                <span>長期記憶摘要已建立</span>
+                <button class="close-memory-window" onclick="closeMemoryWindow()">×</button>
+            </div>
+            <div class="memory-window-body">
+                <div class="memory-window-tokens" id="memoryWindowTokens"></div>
+                <div class="memory-window-summary" id="memoryWindowSummary"></div>
+                <div class="memory-window-keywords" id="memoryWindowKeywords"></div>
+            </div>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add long- and short-term memory tracking with automatic summarisation to conversation persistence and APIs
- return memory state metadata from automation runs and project loading to support the new UI
- refresh the frontend to show attachments, live terminal output, and a memory panel with alert window when thresholds are reached

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e88a6b47408329949125d674bd8383