### PR TITLE
feat: 強化記憶同步與附件呈現

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -15,8 +15,10 @@ import time
 import re
 import json
 import platform
+import mimetypes
 import logging
 import queue
+import hashlib
 from typing import Dict, List, Optional, Tuple, Any
 from datetime import datetime
 from pathlib import Path
@@ -172,8 +174,12 @@ class AIConfig:
                 "auto_error_fix": False,
                 "auto_optimize": False,
                 "auto_test": False,
-                "monitor_interval": 5
+                "monitor_interval": 5,
+                "token_reset_threshold": 120000
             }
+        else:
+            self.automation_settings.setdefault("token_reset_threshold", 120000)
+            self.automation_settings.setdefault("monitor_interval", 5)
 
 @dataclass
 class ConversationMessage:
@@ -194,6 +200,209 @@ class ProjectConversation:
     messages: List[ConversationMessage] = field(default_factory=list)
     created_at: str = ""
     updated_at: str = ""
+    summary: str = ""
+    short_term_memory: List[Dict] = field(default_factory=list)
+    long_term_memory: List[Dict] = field(default_factory=list)
+    quality_score: Optional[int] = None
+    quality_notes: Optional[str] = None
+    memory_notes: Optional[str] = None
+
+
+class MemoryEngine:
+    """負責長短期記憶與摘要評分的核心模組"""
+
+    SUMMARY_MAX_LENGTH = 420
+    STM_LIMIT = 6
+    LTM_LIMIT = 10
+
+    @staticmethod
+    def _clean_text(text: str, length: int = 160) -> str:
+        cleaned = re.sub(r"\s+", " ", text or "").strip()
+        if len(cleaned) > length:
+            return cleaned[: length - 1] + "…"
+        return cleaned
+
+    @staticmethod
+    def build_summary(messages: List[ConversationMessage]) -> str:
+        if not messages:
+            return "尚未開始對話，請輸入需求以建立摘要。"
+
+        focus_segments = []
+        recent_messages = messages[-8:]
+        for msg in recent_messages:
+            prefix = "使用者" if msg.role == 'user' else '助手'
+            focus_segments.append(f"{prefix}：{MemoryEngine._clean_text(msg.content, 120)}")
+
+        summary_body = " / ".join(focus_segments)
+        summary = f"最新進展重點：{summary_body}"
+
+        if len(summary) > MemoryEngine.SUMMARY_MAX_LENGTH:
+            summary = summary[: MemoryEngine.SUMMARY_MAX_LENGTH - 1] + "…"
+
+        return summary
+
+    @staticmethod
+    def build_short_term_memory(messages: List[ConversationMessage]) -> List[Dict]:
+        stm = []
+        for msg in messages[-MemoryEngine.STM_LIMIT:]:
+            stm.append({
+                'role': msg.role,
+                'timestamp': msg.timestamp,
+                'content': MemoryEngine._clean_text(msg.content, 180)
+            })
+        return stm
+
+    @staticmethod
+    def _extract_tags(text: str) -> List[str]:
+        words = re.findall(r"[\w\u4e00-\u9fa5]{2,}", text or "")
+        unique = []
+        for word in words:
+            word = word.lower()
+            if word not in unique:
+                unique.append(word)
+            if len(unique) >= 6:
+                break
+        return unique
+
+    @staticmethod
+    def update_long_term_memory(conversation: ProjectConversation) -> List[Dict]:
+        if not conversation.long_term_memory:
+            conversation.long_term_memory = []
+
+        summary = conversation.summary or MemoryEngine.build_summary(conversation.messages)
+        memory_id_source = f"{conversation.project_dir}-{summary}".encode('utf-8', errors='ignore')
+        memory_id = hashlib.sha1(memory_id_source).hexdigest()[:12]
+        now = datetime.now().isoformat()
+        tags = MemoryEngine._extract_tags(summary)
+
+        existing = next((item for item in conversation.long_term_memory if item.get('memory_id') == memory_id), None)
+
+        if existing:
+            existing['detail'] = summary
+            existing['tags'] = tags
+            existing['last_referenced_at'] = now
+            existing['score'] = min(1.0, float(existing.get('score', 0.7)) + 0.05)
+        else:
+            conversation.long_term_memory.append({
+                'memory_id': memory_id,
+                'title': f"核心摘要 @ {datetime.now().strftime('%Y-%m-%d %H:%M')}",
+                'detail': summary,
+                'tags': tags,
+                'source_messages': list(range(max(len(conversation.messages) - 8, 0), len(conversation.messages))),
+                'score': 0.7,
+                'created_at': now,
+                'last_referenced_at': now
+            })
+
+        conversation.long_term_memory = sorted(
+            conversation.long_term_memory,
+            key=lambda item: item.get('last_referenced_at', ''),
+            reverse=True
+        )[: MemoryEngine.LTM_LIMIT]
+
+        return conversation.long_term_memory
+
+    @staticmethod
+    def evaluate_quality(messages: List[ConversationMessage]) -> Tuple[int, str]:
+        if not messages:
+            return 50, "尚未有任何對話內容，請繼續輸入需求。"
+
+        latest_assistant = next((msg for msg in reversed(messages) if msg.role == 'assistant'), None)
+        if not latest_assistant:
+            return 60, "尚未獲得 AI 回覆。"
+
+        base_score = 85
+        feedback = []
+        content = latest_assistant.content or ""
+        lowered = content.lower()
+
+        if '錯誤' in content or '失敗' in content:
+            base_score -= 20
+            feedback.append('偵測到錯誤或失敗訊息，建議檢查輸出。')
+        if '警告' in content or 'warning' in lowered:
+            base_score -= 5
+            feedback.append('輸出中含有警告訊息，可視情況調整。')
+        if len(content) < 60:
+            base_score -= 5
+            feedback.append('回覆較為精簡，確認是否需要補充細節。')
+
+        base_score = max(0, min(100, base_score))
+        feedback_text = '；'.join(feedback) if feedback else '回覆結構完整，可持續迭代細部功能。'
+        return base_score, feedback_text
+
+    @staticmethod
+    def aggregate_token_usage(messages: List[ConversationMessage]) -> Dict[str, int]:
+        totals = {
+            'prompt_token_count': 0,
+            'candidates_token_count': 0,
+            'thoughts_token_count': 0,
+            'total_token_count': 0
+        }
+
+        for msg in messages:
+            if msg.usage_metadata:
+                for key in totals.keys():
+                    totals[key] += int(msg.usage_metadata.get(key, 0) or 0)
+
+        return totals
+
+    @staticmethod
+    def build_prompt_context(conversation: ProjectConversation) -> str:
+        summary = conversation.summary or MemoryEngine.build_summary(conversation.messages)
+        stm = conversation.short_term_memory or MemoryEngine.build_short_term_memory(conversation.messages)
+        ltm = conversation.long_term_memory or []
+
+        stm_lines = [f"- {('使用者' if item.get('role') == 'user' else '助手')}：{item.get('content')}" for item in stm]
+        ltm_lines = [f"• {memory.get('title')}: {MemoryEngine._clean_text(memory.get('detail', ''), 160)}" for memory in ltm]
+
+        context_sections = [
+            "=== 核心記憶摘要 ===",
+            f"專案總結：{summary}"
+        ]
+
+        if stm_lines:
+            context_sections.append("\n=== 短期記憶 (STM) ===")
+            context_sections.extend(stm_lines)
+
+        if ltm_lines:
+            context_sections.append("\n=== 長期記憶 (LTM) ===")
+            context_sections.extend(ltm_lines)
+
+        if conversation.memory_notes:
+            context_sections.append("\n=== 記憶備註 ===")
+            context_sections.append(conversation.memory_notes)
+
+        context_sections.append("\n=== 評分規則提醒 ===")
+        context_sections.append("請在輸出結尾提供品質評分與精簡評語，並根據需求更新記憶內容。")
+
+        return "\n".join(context_sections)
+
+    @staticmethod
+    def refresh_conversation(conversation: ProjectConversation, meta: Optional[Dict] = None) -> ProjectConversation:
+        conversation.summary = MemoryEngine.build_summary(conversation.messages)
+        conversation.short_term_memory = MemoryEngine.build_short_term_memory(conversation.messages)
+        MemoryEngine.update_long_term_memory(conversation)
+
+        if meta:
+            score = meta.get('quality_score')
+            comment = meta.get('quality_summary') or meta.get('quality_comment')
+            memory_note = meta.get('memory_notes')
+            if score is not None:
+                conversation.quality_score = int(score)
+            if comment:
+                conversation.quality_notes = comment
+            if memory_note:
+                conversation.memory_notes = memory_note
+
+        if conversation.quality_score is None or conversation.quality_notes is None:
+            evaluated_score, evaluated_notes = MemoryEngine.evaluate_quality(conversation.messages)
+            conversation.quality_score = conversation.quality_score or evaluated_score
+            conversation.quality_notes = conversation.quality_notes or evaluated_notes
+
+        if not conversation.memory_notes and conversation.long_term_memory:
+            conversation.memory_notes = conversation.long_term_memory[0].get('detail')
+
+        return conversation
 
 @dataclass
 class ProcessResult:
@@ -211,6 +420,16 @@ class ProcessResult:
     is_iteration: bool = False
     usage_metadata: Optional[Dict] = None
     terminal_output: str = ""
+    conversation_summary: str = ""
+    short_term_memory: List[Dict] = field(default_factory=list)
+    long_term_memory: List[Dict] = field(default_factory=list)
+    quality_score: Optional[int] = None
+    quality_feedback: Optional[str] = None
+    memory_notes: Optional[str] = None
+    token_usage_totals: Dict[str, int] = field(default_factory=dict)
+    user_terminal_snapshot: Optional[str] = None
+    message_metadata: Optional[Dict] = None
+    message_attachments: List[Dict] = field(default_factory=list)
 
 # ============================================
 # JSON Schema 定義 - 繁體中文化
@@ -250,6 +469,16 @@ def get_json_schema():
                         "web_title": {"type": ["string", "null"], "description": "網頁標題"}
                     },
                     "required": ["filename", "filetype", "code", "opens_window"]
+                }
+            },
+            "meta": {
+                "type": "object",
+                "description": "評分與記憶補充資訊",
+                "properties": {
+                    "quality_score": {"type": "integer", "minimum": 0, "maximum": 100, "description": "AI 對本次輸出的自評分數"},
+                    "quality_summary": {"type": "string", "description": "對品質的精簡評語"},
+                    "memory_notes": {"type": "string", "description": "需寫入長期記憶的關鍵要點"},
+                    "next_steps": {"type": "array", "items": {"type": "string"}, "description": "後續建議行動"}
                 }
             }
         },
@@ -350,6 +579,11 @@ python, javascript, html, css, typescript, java, cpp, c, go, rust, ruby, php, sw
    - API 端點可訪問
    - 前後端數據交互正常
 
+=== 核心回應規則 ===
+1. 所有輸出必須遵守「AI Assistant Core Directives」: 先呈現主要內容,再以分隔線與評分資訊結尾。
+2. 若提供 meta 欄位,請確保 quality_score 為 0-100 之間的整數,並給出繁體中文精簡評語。
+3. memory_notes 與 next_steps 用於更新記憶模組,請聚焦於可長期留存的重點與後續行動。
+
 Terminal 輸出和除錯資訊:
 1. 所有重要的執行步驟都應該有 print() 或 console.log() 輸出
 2. 包含適當的錯誤處理和錯誤訊息輸出
@@ -436,10 +670,16 @@ class ConversationManager:
                 project_dir=project_dir,
                 project_name=project_name,
                 created_at=datetime.now().isoformat(),
-                updated_at=datetime.now().isoformat()
+                updated_at=datetime.now().isoformat(),
+                summary="",
+                short_term_memory=[],
+                long_term_memory=[],
+                quality_score=None,
+                quality_notes=None,
+                memory_notes=None
             )
             return conv
-        
+
         try:
             with open(conv_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
@@ -460,13 +700,19 @@ class ConversationManager:
                         terminal_output=msg_data.get('terminal_output'),
                         usage_metadata=usage_metadata  # ⭐ 直接保存
                     ))
-                
+
                 return ProjectConversation(
                     project_dir=data['project_dir'],
                     project_name=data['project_name'],
                     messages=messages,
                     created_at=data.get('created_at', ''),
-                    updated_at=data.get('updated_at', '')
+                    updated_at=data.get('updated_at', ''),
+                    summary=data.get('summary', ''),
+                    short_term_memory=data.get('short_term_memory', []),
+                    long_term_memory=data.get('long_term_memory', []),
+                    quality_score=data.get('quality_score'),
+                    quality_notes=data.get('quality_notes'),
+                    memory_notes=data.get('memory_notes')
                 )
         except Exception as e:
             logger.error(f"載入對話歷史失敗: {e}")
@@ -474,16 +720,24 @@ class ConversationManager:
                 project_dir=project_dir,
                 project_name=Path(project_dir).name,
                 created_at=datetime.now().isoformat(),
-                updated_at=datetime.now().isoformat()
+                updated_at=datetime.now().isoformat(),
+                summary="",
+                short_term_memory=[],
+                long_term_memory=[],
+                quality_score=None,
+                quality_notes=None,
+                memory_notes=None
             )
-    
+
     @staticmethod
-    def save_conversation(conversation: ProjectConversation) -> bool:
+    def save_conversation(conversation: ProjectConversation, meta: Optional[Dict] = None) -> bool:
         """儲存對話歷史 - 正確序列化 usage_metadata"""
         try:
             conv_file = ConversationManager.get_conversation_file(conversation.project_dir)
             conversation.updated_at = datetime.now().isoformat()
-            
+
+            MemoryEngine.refresh_conversation(conversation, meta)
+
             # ⭐ 關鍵修復：使用自定義序列化保留 usage_metadata
             messages_data = []
             for msg in conversation.messages:
@@ -503,12 +757,18 @@ class ConversationManager:
                 'project_name': conversation.project_name,
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'summary': conversation.summary,
+                'short_term_memory': conversation.short_term_memory,
+                'long_term_memory': conversation.long_term_memory,
+                'quality_score': conversation.quality_score,
+                'quality_notes': conversation.quality_notes,
+                'memory_notes': conversation.memory_notes
             }
-            
+
             with open(conv_file, 'w', encoding='utf-8') as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
-            
+
             logger.info(f"對話歷史已儲存: {conversation.project_name}")
             return True
         except Exception as e:
@@ -531,9 +791,14 @@ class ConversationManager:
             terminal_output=terminal_output,
             usage_metadata=usage_metadata  # ⭐ 直接保存
         )
-        
+
         conversation.messages.append(message)
-        ConversationManager.save_conversation(conversation)
+        meta_payload = None
+        if metadata and isinstance(metadata, dict):
+            meta_payload = metadata.get('meta')
+
+        ConversationManager.save_conversation(conversation, meta_payload)
+        return conversation
     
     @staticmethod
     def delete_conversation_file(project_dir: str) -> bool:
@@ -715,12 +980,12 @@ class GeminiAI:
             raise ValueError(f"不支持的連接模式: {config.connection_method}")
     
     @staticmethod
-    def generate_content(prompt: str, config: AIConfig, files: List[Dict] = None, 
-                        terminal_output: str = None) -> Tuple[str, Optional[Dict], Optional[Dict]]:
+    def generate_content(prompt: str, config: AIConfig, files: List[Dict] = None,
+                        terminal_output: str = None, memory_context: Optional[str] = None) -> Tuple[str, Optional[Dict], Optional[Dict]]:
         """呼叫 Gemini API 生成內容(支持檔案和Terminal輸出)"""
         try:
             GeminiAI.configure(config)
-            
+
             gen_params = dict(config.generation_params)
             gen_params["response_mime_type"] = "application/json"
             
@@ -761,9 +1026,13 @@ class GeminiAI:
             model_kwargs["generation_config"] = gen_config
             
             model = genai.GenerativeModel(**model_kwargs)
-            
+
             content_parts = []
-            
+
+            if memory_context:
+                content_parts.append(memory_context)
+                logger.info("已注入長短期記憶上下文")
+
             if terminal_output:
                 terminal_part = f"\n=== 程式執行輸出 (Terminal Output) ===\n{terminal_output}\n=== 輸出結束 ===\n"
                 content_parts.append(terminal_part)
@@ -1665,6 +1934,22 @@ class ProcessManager:
         """執行完整的自動化流程 - 修復版"""
         
         result = ProcessResult(success=False, is_iteration=is_iteration)
+
+        def _safe_relative_path(path_str: Optional[str], base_dir: str) -> str:
+            if not path_str:
+                return ""
+            try:
+                base_path = Path(base_dir)
+                return str(Path(path_str).resolve().relative_to(base_path.resolve()))
+            except Exception:
+                try:
+                    return Path(path_str).name
+                except Exception:
+                    return str(path_str)
+
+        def _guess_attachment_type(filename: str) -> str:
+            guessed, _ = mimetypes.guess_type(filename or "")
+            return guessed or 'text/plain'
         
         try:
             if is_iteration:
@@ -1683,15 +1968,18 @@ class ProcessManager:
                 if terminal_output:
                     logger.info("已附加Terminal輸出到AI請求")
                     result.terminal_output = terminal_output
-            
+                    result.user_terminal_snapshot = terminal_output
+
             # ⭐ 修復:在正確的時機保存用戶消息
-            ConversationManager.add_message(
+            conversation_after_user = ConversationManager.add_message(
                 folder_path,
                 'user',
                 prompt,
                 files=[{'name': f.get('name'), 'type': f.get('type')} for f in (files or [])],
                 terminal_output=terminal_output
             )
+
+            memory_context = MemoryEngine.build_prompt_context(conversation_after_user)
             
             if is_iteration and attach_screenshot:
                 project_info = ProjectManager.load_project_info(folder_path)
@@ -1760,12 +2048,25 @@ class ProcessManager:
                 logger.info("包含 Terminal 輸出")
             
             ai_response, json_data, usage_metadata = GeminiAI.generate_content(
-                prompt, config, files, terminal_output
+                prompt, config, files, terminal_output, memory_context
             )
             result.ai_response = ai_response
             result.ai_response_json = json_data
             result.usage_metadata = usage_metadata
-            
+
+            meta_info = {}
+            if isinstance(result.ai_response_json, dict):
+                meta_info = result.ai_response_json.get('meta') or {}
+                if meta_info.get('quality_score') is not None:
+                    try:
+                        result.quality_score = int(meta_info.get('quality_score'))
+                    except (TypeError, ValueError):
+                        result.quality_score = None
+                if meta_info.get('quality_summary') or meta_info.get('quality_comment'):
+                    result.quality_feedback = meta_info.get('quality_summary') or meta_info.get('quality_comment')
+                if meta_info.get('memory_notes'):
+                    result.memory_notes = meta_info.get('memory_notes')
+
             logger.info("Step 2: 解析 AI 回應...")
             try:
                 if json_data:
@@ -1848,8 +2149,17 @@ class ProcessManager:
             # Step 5: 儲存專案檔案
             logger.info("Step 5: 儲存專案檔案...")
             saved_files, updated_files = CodeProcessor.save_project_files(folder_path, project, is_iteration)
-            result.files_created = saved_files
-            result.files_updated = updated_files
+
+            result.files_created = [
+                _safe_relative_path(path, final_project_dir)
+                for path in saved_files
+                if path
+            ]
+            result.files_updated = [
+                _safe_relative_path(path, final_project_dir)
+                for path in updated_files
+                if path
+            ]
             
             # ⭐ 關鍵修復:確定最終的專案目錄
             if is_iteration:
@@ -2049,17 +2359,72 @@ class ProcessManager:
             result.success = True
             
             # ⭐ 關鍵修復:使用最終路徑和正確的 usage_metadata 保存AI回應
+            assistant_attachments: List[Dict[str, Any]] = []
+            for created in result.files_created:
+                if created:
+                    assistant_attachments.append({
+                        'name': created,
+                        'type': _guess_attachment_type(created),
+                        'label': '新增檔案'
+                    })
+            for updated in result.files_updated:
+                if updated:
+                    assistant_attachments.append({
+                        'name': updated,
+                        'type': _guess_attachment_type(updated),
+                        'label': '更新檔案'
+                    })
+            screenshot_names = []
+            for screenshot in result.screenshots:
+                name = Path(screenshot).name if screenshot else ''
+                if name:
+                    screenshot_names.append(name)
+                    assistant_attachments.append({
+                        'name': name,
+                        'type': 'image/png',
+                        'label': '截圖',
+                        'url': f"/screenshot/{name}"
+                    })
+
+            assistant_metadata = {
+                'project_name': project.project_name,
+                'files_count': len(project.files),
+                'meta': meta_info,
+                'quality_score': result.quality_score,
+                'quality_feedback': result.quality_feedback,
+                'memory_notes': result.memory_notes,
+                'attachments': assistant_attachments,
+                'files_created': result.files_created,
+                'files_updated': result.files_updated,
+                'screenshots': screenshot_names
+            }
+
             ConversationManager.add_message(
                 final_project_dir,  # ✅ 使用最終專案路徑
                 'assistant',
                 result.output,
-                metadata={
-                    'project_name': project.project_name,
-                    'files_count': len(project.files)
-                },
+                files=assistant_attachments,
+                metadata=assistant_metadata,
                 terminal_output=result.terminal_output,
                 usage_metadata=usage_metadata  # ⭐ 直接傳遞 usage_metadata
             )
+
+            updated_conversation = ConversationManager.load_conversation(final_project_dir)
+            result.conversation_summary = updated_conversation.summary
+            result.short_term_memory = updated_conversation.short_term_memory
+            result.long_term_memory = updated_conversation.long_term_memory
+            aggregate_tokens = MemoryEngine.aggregate_token_usage(updated_conversation.messages)
+            result.token_usage_totals = aggregate_tokens
+
+            result.message_metadata = assistant_metadata
+            result.message_attachments = assistant_attachments
+
+            if updated_conversation.quality_score is not None:
+                result.quality_score = updated_conversation.quality_score
+            if updated_conversation.quality_notes:
+                result.quality_feedback = updated_conversation.quality_notes
+            if updated_conversation.memory_notes:
+                result.memory_notes = updated_conversation.memory_notes
             
         except Exception as e:
             result.error = str(e)
@@ -2180,6 +2545,8 @@ def load_project():
             }
             messages_data.append(msg_dict)
         
+        token_usage_snapshot = MemoryEngine.aggregate_token_usage(conversation.messages)
+
         return jsonify({
             'success': True,
             'project_info': project_info,
@@ -2189,7 +2556,14 @@ def load_project():
             'conversation': {
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'summary': conversation.summary,
+                'short_term_memory': conversation.short_term_memory,
+                'long_term_memory': conversation.long_term_memory,
+                'quality_score': conversation.quality_score,
+                'quality_notes': conversation.quality_notes,
+                'memory_notes': conversation.memory_notes,
+                'token_usage': token_usage_snapshot
             }
         })
         
@@ -2223,13 +2597,22 @@ def get_conversation(project_dir):
             }
             messages_data.append(msg_dict)
         
+        token_usage_snapshot = MemoryEngine.aggregate_token_usage(conversation.messages)
+
         return jsonify({
             'success': True,
             'conversation': {
                 'project_name': conversation.project_name,
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'summary': conversation.summary,
+                'short_term_memory': conversation.short_term_memory,
+                'long_term_memory': conversation.long_term_memory,
+                'quality_score': conversation.quality_score,
+                'quality_notes': conversation.quality_notes,
+                'memory_notes': conversation.memory_notes,
+                'token_usage': token_usage_snapshot
             }
         })
     except Exception as e:
@@ -2324,9 +2707,23 @@ def run_process():
             'screenshots': result.screenshots,
             'is_iteration': result.is_iteration,
             'usage_metadata': result.usage_metadata,
-            'terminal_output': result.terminal_output
+            'terminal_output': result.terminal_output,
+            'memory_snapshot': {
+                'summary': result.conversation_summary,
+                'short_term_memory': result.short_term_memory,
+                'long_term_memory': result.long_term_memory,
+                'quality_score': result.quality_score,
+                'quality_feedback': result.quality_feedback,
+                'memory_notes': result.memory_notes,
+                'token_usage': result.token_usage_totals
+            },
+            'message_metadata': result.message_metadata,
+            'message_attachments': result.message_attachments
         }
-        
+
+        if result.user_terminal_snapshot:
+            response_data['user_terminal_snapshot'] = result.user_terminal_snapshot
+
         if result.project_data:
             response_data['project'] = {
                 'name': result.project_data.project_name,

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -13,6 +13,17 @@ let allProjects = [];
 let modelConfig = null;
 let sidebarCollapsed = false;
 let MODEL_LIMITS = {};
+let conversationInsights = null;
+let lastUserMessageElement = null;
+let cachedTokenThreshold = 120000;
+let tokenThresholdTriggered = false;
+let tokenUsageSnapshot = {
+    prompt_token_count: 0,
+    candidates_token_count: 0,
+    thoughts_token_count: 0,
+    total_token_count: 0
+};
+let conversationRefreshTimer = null;
 
 // ============================================
 // Loading Overlay 控制 - 修復版
@@ -95,6 +106,15 @@ async function loadConfig() {
             'gemini-1.5-flash': { name: 'Gemini 1.5 Flash', inputLimit: 1048576, outputLimit: 8192 }
         };
         modelConfig = config;
+        const autoSettings = config.automation_settings || {};
+        cachedTokenThreshold = parseInt(autoSettings.token_reset_threshold || 120000);
+        tokenThresholdTriggered = false;
+        tokenUsageSnapshot = {
+            prompt_token_count: 0,
+            candidates_token_count: 0,
+            thoughts_token_count: 0,
+            total_token_count: 0
+        };
     } catch (error) {
         console.error('載入配置失敗:', error);
     }
@@ -327,7 +347,12 @@ async function handleSubmit() {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
 
-    addMessage('user', prompt);
+    const submittedFiles = uploadedFiles.map(file => ({
+        name: file.name,
+        type: file.type || 'text/plain'
+    }));
+
+    lastUserMessageElement = addMessage('user', prompt, null, null, submittedFiles);
 
     input.value = '';
     updateSubmitButton();
@@ -355,8 +380,20 @@ async function handleSubmit() {
         const result = await response.json();
 
         if (result.success) {
-            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output);
-            
+            addMessage(
+                'assistant',
+                result.output,
+                result.usage_metadata,
+                result.terminal_output,
+                result.message_attachments,
+                result.memory_snapshot,
+                result.message_metadata
+            );
+
+            if (result.user_terminal_snapshot) {
+                patchMessageWithTerminal(lastUserMessageElement, result.user_terminal_snapshot);
+            }
+
             if (result.project) {
                 currentProject = result.project;
                 if (result.ai_response_json) {
@@ -380,27 +417,45 @@ async function handleSubmit() {
             }
 
             showNotification(result.is_iteration ? '專案迭代成功!' : '專案創建成功!', 'success');
-            
+
             loadProjectsList();
+            updateConversationInsights(result.memory_snapshot);
+            checkTokenThreshold(result.memory_snapshot?.token_usage);
+
+            if (currentProjectDir) {
+                scheduleConversationRefresh();
+            }
+
             uploadedFiles = [];
             updateFilesPreview();
             updateAttachedFilesDisplay();
+            lastUserMessageElement = null;
         } else {
             addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`);
             showNotification(`執行失敗：${result.error}`, 'error');
+            lastUserMessageElement = null;
+
+            if (currentProjectDir) {
+                scheduleConversationRefresh(2000);
+            }
         }
     } catch (error) {
         addMessage('assistant', `✕ 連接錯誤：${error}`);
         showNotification(`連接錯誤：${error}`, 'error');
+        lastUserMessageElement = null;
+
+        if (currentProjectDir) {
+            scheduleConversationRefresh(2000);
+        }
     } finally {
         hideLoading();
     }
 }
 
-function addMessage(role, content, usageMetadata = null, terminalOutput = null) {
+function addMessage(role, content, usageMetadata = null, terminalOutput = null, files = null, metaSnapshot = null, metadata = null, options = {}) {
     const container = document.getElementById('resultsContainer');
     if (!container) return;
-    
+
     const message = document.createElement('div');
     message.className = `result-message ${role} selectable`;
 
@@ -420,25 +475,96 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
 
     const messageContent = document.createElement('div');
     messageContent.className = 'message-content selectable';
-    messageContent.textContent = content;
+
+    const messageText = document.createElement('pre');
+    messageText.className = 'message-text';
+    messageText.textContent = content || '';
+
+    messageContent.appendChild(messageText);
 
     message.appendChild(header);
     message.appendChild(messageContent);
-    
-    // ✅ Terminal輸出只顯示在用戶消息中
-    if (role === 'user' && terminalOutput && terminalOutput.trim()) {
+
+    const normalizedFiles = normalizeFilesForDisplay(files, metadata);
+    if (normalizedFiles.length > 0) {
+        const attachmentsBlock = document.createElement('div');
+        attachmentsBlock.className = 'message-attachments';
+
+        const title = document.createElement('div');
+        title.className = 'attachment-title';
+        title.textContent = `附件 (${normalizedFiles.length})`;
+
+        const list = document.createElement('div');
+        list.className = 'attachment-list';
+
+        normalizedFiles.forEach(file => {
+            const item = document.createElement('div');
+            item.className = 'attachment-item';
+
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'attachment-icon';
+            iconSpan.textContent = getFileIcon(file.name);
+
+            const infoWrap = document.createElement('div');
+            infoWrap.className = 'attachment-info';
+
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'attachment-name';
+            nameSpan.textContent = file.name;
+            infoWrap.appendChild(nameSpan);
+
+            if (file.label) {
+                const badge = document.createElement('span');
+                badge.className = 'attachment-badge';
+                badge.textContent = file.label;
+                infoWrap.appendChild(badge);
+            }
+
+            if (file.note) {
+                const noteSpan = document.createElement('span');
+                noteSpan.className = 'attachment-note';
+                noteSpan.textContent = file.note;
+                infoWrap.appendChild(noteSpan);
+            }
+
+            item.appendChild(iconSpan);
+            item.appendChild(infoWrap);
+
+            if (file.url) {
+                item.classList.add('attachment-clickable');
+                item.addEventListener('click', () => {
+                    window.open(file.url, '_blank', 'noopener');
+                });
+            }
+
+            list.appendChild(item);
+        });
+
+        attachmentsBlock.appendChild(title);
+        attachmentsBlock.appendChild(list);
+        message.appendChild(attachmentsBlock);
+    }
+
+    if (terminalOutput && terminalOutput.trim()) {
         const terminalSection = document.createElement('div');
         terminalSection.className = 'terminal-output-section';
-        terminalSection.innerHTML = `
-            <div class="terminal-header">
-                <span class="terminal-title">Terminal 輸出</span>
-            </div>
-            <div class="terminal-body selectable">${terminalOutput}</div>
-        `;
+
+        const headerEl = document.createElement('div');
+        headerEl.className = 'terminal-header';
+        const titleEl = document.createElement('span');
+        titleEl.className = 'terminal-title';
+        titleEl.textContent = 'Terminal 輸出';
+        headerEl.appendChild(titleEl);
+
+        const body = document.createElement('div');
+        body.className = 'terminal-body selectable';
+        body.textContent = terminalOutput;
+
+        terminalSection.appendChild(headerEl);
+        terminalSection.appendChild(body);
         message.appendChild(terminalSection);
     }
-    
-    // Token使用統計只顯示在AI回應中
+
     if (role === 'assistant' && usageMetadata && typeof usageMetadata === 'object') {
         const tokenUsage = document.createElement('div');
         tokenUsage.className = 'token-usage';
@@ -462,9 +588,492 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
         `;
         message.appendChild(tokenUsage);
     }
-    
+
+    if (metaSnapshot && metaSnapshot.quality_score != null && role === 'assistant') {
+        const badge = document.createElement('div');
+        badge.className = 'token-chip';
+        badge.innerHTML = `<strong>評分</strong>${metaSnapshot.quality_score} / ${metaSnapshot.quality_feedback || '未提供說明'}`;
+        message.appendChild(badge);
+    }
+
     container.appendChild(message);
-    message.scrollIntoView({ behavior: 'smooth' });
+    if (options.scroll !== false) {
+        message.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
+    return message;
+}
+
+function normalizeFilesForDisplay(files, metadata) {
+    const normalized = [];
+    const seen = new Set();
+
+    const pushFile = (file, fallback = {}) => {
+        if (!file) return;
+        if (typeof file === 'string') {
+            pushFile({ name: file }, fallback);
+            return;
+        }
+        const name = file.name || file.filename || file.path || file.filepath || '';
+        if (!name) return;
+        const label = file.label || file.status || fallback.label || '';
+        const note = file.note || file.description || fallback.note || '';
+        const key = `${name}|${label}|${note}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        normalized.push({
+            name,
+            type: file.type || file.filetype || fallback.type || 'text/plain',
+            label,
+            note,
+            url: file.url || file.href || fallback.url || null
+        });
+    };
+
+    if (Array.isArray(files)) {
+        files.forEach(file => pushFile(file));
+    }
+
+    if (metadata && typeof metadata === 'object') {
+        const metadataSources = [
+            { key: 'attachments', fallback: {} },
+            { key: 'files', fallback: {} },
+            { key: 'files_created', fallback: { label: '新增檔案' } },
+            { key: 'files_updated', fallback: { label: '更新檔案' } },
+            { key: 'generated_files', fallback: { label: '產出檔案' } },
+            { key: 'updated_files', fallback: { label: '更新檔案' } }
+        ];
+
+        metadataSources.forEach(({ key, fallback }) => {
+            const value = metadata[key];
+            if (Array.isArray(value)) {
+                value.forEach(item => pushFile(item, fallback));
+            }
+        });
+
+        if (Array.isArray(metadata.screenshots)) {
+            metadata.screenshots.forEach(item => {
+                if (typeof item === 'string') {
+                    pushFile({ name: item, type: 'image/png', label: '截圖', url: `/screenshot/${item}` });
+                } else if (item && typeof item === 'object') {
+                    pushFile({
+                        name: item.name || item.filename,
+                        type: item.type || 'image/png',
+                        label: item.label || '截圖',
+                        url: item.url || item.href || `/screenshot/${item.name || item.filename}`
+                    });
+                }
+            });
+        }
+    }
+
+    return normalized;
+}
+
+function getFileIcon(filename) {
+    if (!filename) return '📄';
+    const parts = filename.split('.');
+    const ext = parts.length > 1 ? parts.pop().toLowerCase() : '';
+    const iconMap = {
+        py: '🐍',
+        js: '🟨',
+        ts: '🟦',
+        json: '🗂️',
+        html: '🌐',
+        css: '🎨',
+        md: '📝',
+        txt: '📄',
+        png: '🖼️',
+        jpg: '🖼️',
+        jpeg: '🖼️',
+        svg: '🖼️',
+        pdf: '📕',
+        yml: '⚙️',
+        yaml: '⚙️',
+        sh: '💻'
+    };
+    return iconMap[ext] || '📄';
+}
+
+function patchMessageWithTerminal(messageElement, terminalOutput) {
+    if (!messageElement || !terminalOutput || !terminalOutput.trim()) return;
+    let terminalSection = messageElement.querySelector('.terminal-output-section');
+    if (!terminalSection) {
+        terminalSection = document.createElement('div');
+        terminalSection.className = 'terminal-output-section';
+
+        const headerEl = document.createElement('div');
+        headerEl.className = 'terminal-header';
+        const titleEl = document.createElement('span');
+        titleEl.className = 'terminal-title';
+        titleEl.textContent = 'Terminal 輸出';
+        headerEl.appendChild(titleEl);
+
+        const body = document.createElement('div');
+        body.className = 'terminal-body selectable';
+        body.textContent = terminalOutput;
+
+        terminalSection.appendChild(headerEl);
+        terminalSection.appendChild(body);
+        messageElement.appendChild(terminalSection);
+    } else {
+        const body = terminalSection.querySelector('.terminal-body');
+        if (body) {
+            body.textContent = terminalOutput;
+        }
+    }
+}
+
+function renderConversationHistory(conversation) {
+    const container = document.getElementById('resultsContainer');
+    if (!container) return;
+
+    container.innerHTML = '';
+
+    const messages = conversation?.messages || [];
+    if (!Array.isArray(messages) || messages.length === 0) {
+        lastUserMessageElement = null;
+        return;
+    }
+
+    messages.forEach((msg, index) => {
+        const metaSnapshot = msg?.metadata?.meta || null;
+        addMessage(
+            msg.role,
+            msg.content,
+            msg.usage_metadata,
+            msg.terminal_output,
+            msg.files,
+            metaSnapshot,
+            msg.metadata,
+            { scroll: index === messages.length - 1 }
+        );
+    });
+
+    lastUserMessageElement = null;
+}
+
+function cancelConversationRefreshTimer() {
+    if (conversationRefreshTimer) {
+        clearTimeout(conversationRefreshTimer);
+        conversationRefreshTimer = null;
+    }
+}
+
+function scheduleConversationRefresh(delay = 1500) {
+    cancelConversationRefreshTimer();
+    conversationRefreshTimer = setTimeout(() => {
+        refreshConversationFromServer();
+    }, Math.max(0, delay));
+}
+
+async function refreshConversationFromServer() {
+    if (!currentProjectDir) {
+        cancelConversationRefreshTimer();
+        return;
+    }
+
+    try {
+        const response = await fetch(`/conversation/${encodeURIComponent(currentProjectDir)}`);
+        const result = await response.json();
+
+        if (result.success) {
+            renderConversationHistory(result.conversation);
+            updateConversationInsights(result.conversation);
+            checkTokenThreshold(result.conversation?.token_usage, { skipAuto: true });
+        }
+    } catch (error) {
+        console.error('同步對話失敗:', error);
+    } finally {
+        conversationRefreshTimer = null;
+    }
+}
+
+function renderMemoryList(elementId, items, type = 'stm') {
+    const listEl = document.getElementById(elementId);
+    if (!listEl) return;
+    listEl.innerHTML = '';
+
+    if (!items || items.length === 0) {
+        const empty = document.createElement('li');
+        empty.textContent = '尚無紀錄。';
+        listEl.appendChild(empty);
+        return;
+    }
+
+    items.forEach(item => {
+        const li = document.createElement('li');
+
+        if (type === 'stm') {
+            const roleLabel = item.role === 'user' ? '使用者' : '助手';
+            li.textContent = `${roleLabel}：${item.content || ''}`;
+        } else {
+            if (item.tags && item.tags.length) {
+                const tagsRow = document.createElement('div');
+                item.tags.slice(0, 3).forEach(tag => {
+                    const span = document.createElement('span');
+                    span.className = 'memory-tag';
+                    span.textContent = tag;
+                    tagsRow.appendChild(span);
+                });
+                li.appendChild(tagsRow);
+            }
+
+            const detail = document.createElement('div');
+            detail.textContent = item.detail || item.title || '無內容';
+            li.appendChild(detail);
+        }
+
+        listEl.appendChild(li);
+    });
+}
+
+function renderTokenUsageFooter(tokenUsage) {
+    const footer = document.getElementById('tokenUsageFooter');
+    if (!footer) return;
+
+    footer.innerHTML = '';
+    const usage = tokenUsage || {};
+    const entries = [
+        { label: '輸入', value: usage.prompt_token_count || 0 },
+        { label: '輸出', value: usage.candidates_token_count || 0 },
+        { label: '思考', value: usage.thoughts_token_count || 0 },
+        { label: '總計', value: usage.total_token_count || 0 }
+    ];
+
+    entries.forEach(entry => {
+        const chip = document.createElement('div');
+        chip.className = 'token-chip';
+        chip.innerHTML = `<strong>${entry.label}</strong>${entry.value.toLocaleString()}`;
+        footer.appendChild(chip);
+    });
+}
+
+function getQualityScoreColor(score) {
+    if (Number.isNaN(score)) return '#9ca3af';
+    if (score >= 90) return '#0ea5e9';
+    if (score >= 75) return '#10a37f';
+    if (score >= 60) return '#f97316';
+    return '#ef4444';
+}
+
+function updateConversationInsights(insights) {
+    const container = document.getElementById('conversationInsights');
+    const banner = document.getElementById('tokenThresholdBanner');
+
+    if (!container) return;
+
+    if (!insights) {
+        conversationInsights = null;
+        container.style.display = 'none';
+        if (banner) banner.classList.remove('active');
+        tokenUsageSnapshot = {
+            prompt_token_count: 0,
+            candidates_token_count: 0,
+            thoughts_token_count: 0,
+            total_token_count: 0
+        };
+        const bannerText = document.getElementById('tokenBannerText');
+        if (bannerText) {
+            bannerText.textContent = '對話 token 尚未超出閾值。';
+        }
+        return;
+    }
+
+    conversationInsights = insights;
+    container.style.display = 'block';
+
+    const summaryEl = document.getElementById('insightSummary');
+    if (summaryEl) {
+        summaryEl.textContent = insights.summary || '尚未產生摘要。';
+    }
+
+    const badge = document.getElementById('qualityScoreBadge');
+    if (badge) {
+        if (insights.quality_score != null) {
+            badge.textContent = insights.quality_score;
+            badge.style.background = getQualityScoreColor(Number(insights.quality_score));
+        } else {
+            badge.textContent = '--';
+            badge.style.background = '#9ca3af';
+        }
+    }
+
+    const feedbackEl = document.getElementById('qualityFeedbackText');
+    if (feedbackEl) {
+        feedbackEl.textContent = insights.quality_feedback || '尚未產生評語。';
+    }
+
+    const notesEl = document.getElementById('memoryNotesText');
+    if (notesEl) {
+        if (insights.memory_notes) {
+            notesEl.style.display = 'block';
+            notesEl.textContent = insights.memory_notes;
+        } else {
+            notesEl.style.display = 'none';
+            notesEl.textContent = '';
+        }
+    }
+
+    renderMemoryList('stmList', insights.short_term_memory, 'stm');
+    renderMemoryList('ltmList', insights.long_term_memory, 'ltm');
+    renderTokenUsageFooter(insights.token_usage);
+
+    tokenUsageSnapshot = {
+        prompt_token_count: insights.token_usage?.prompt_token_count || 0,
+        candidates_token_count: insights.token_usage?.candidates_token_count || 0,
+        thoughts_token_count: insights.token_usage?.thoughts_token_count || 0,
+        total_token_count: insights.token_usage?.total_token_count || 0
+    };
+
+    const bannerText = document.getElementById('tokenBannerText');
+    if (bannerText) {
+        bannerText.textContent = `當前累積 ${tokenUsageSnapshot.total_token_count.toLocaleString()} tokens / 閾值 ${cachedTokenThreshold.toLocaleString()} tokens`;
+    }
+}
+
+function checkTokenThreshold(tokenUsage, options = {}) {
+    const { skipAuto = false } = options;
+    const banner = document.getElementById('tokenThresholdBanner');
+
+    if (!tokenUsage) {
+        if (banner) banner.classList.remove('active');
+        tokenThresholdTriggered = false;
+        return;
+    }
+
+    const total = parseInt(tokenUsage.total_token_count || 0, 10);
+
+    if (banner) {
+        if (total >= cachedTokenThreshold) {
+            banner.classList.add('active');
+        } else {
+            banner.classList.remove('active');
+        }
+    }
+
+    if (total < cachedTokenThreshold) {
+        tokenThresholdTriggered = false;
+        return;
+    }
+
+    if (!tokenThresholdTriggered && !skipAuto) {
+        tokenThresholdTriggered = true;
+        showTokenOverflowWarning(total);
+    } else if (!tokenThresholdTriggered && skipAuto) {
+        tokenThresholdTriggered = true;
+        const text = document.getElementById('tokenBannerText');
+        if (text) {
+            text.textContent = `對話累積 ${total.toLocaleString()} tokens，已超過設定閾值 ${cachedTokenThreshold.toLocaleString()} tokens。`;
+        }
+    } else {
+        const text = document.getElementById('tokenBannerText');
+        if (text) {
+            text.textContent = `對話累積 ${total.toLocaleString()} tokens，已超過設定閾值 ${cachedTokenThreshold.toLocaleString()} tokens。`;
+        }
+    }
+}
+
+function showTokenOverflowWarning(totalTokens) {
+    const banner = document.getElementById('tokenThresholdBanner');
+    if (banner) {
+        banner.classList.add('active');
+    }
+
+    const text = document.getElementById('tokenBannerText');
+    if (text) {
+        const safeTotal = Number(totalTokens) || 0;
+        text.textContent = `對話累積 ${safeTotal.toLocaleString()} tokens，已超過設定閾值 ${cachedTokenThreshold.toLocaleString()} tokens，建議重整對話。`;
+    }
+
+    tokenThresholdTriggered = true;
+    spawnTokenHelperWindow(totalTokens, true);
+}
+
+function spawnTokenHelperWindow(totalTokens, auto = false) {
+    try {
+        const helperWindow = window.open('', '_blank');
+        if (!helperWindow) {
+            if (auto) {
+                showNotification('瀏覽器阻擋了自動視窗，請允許快顯或手動點擊提醒按鈕。', 'warning');
+            }
+            return;
+        }
+
+        const summary = conversationInsights?.summary || '尚未產生摘要。';
+        const qualityScore = conversationInsights?.quality_score ?? '--';
+        const qualityFeedback = conversationInsights?.quality_feedback || '尚未產生評語。';
+        const stmItems = conversationInsights?.short_term_memory || [];
+        const ltmItems = conversationInsights?.long_term_memory || [];
+        const safeTotal = Number(totalTokens) || 0;
+
+        helperWindow.document.write(`<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8">
+<title>Token 閾值整理視窗</title>
+<style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 24px; background: #f7f7f8; color: #111827; }
+    h1 { margin-top: 0; font-size: 20px; }
+    section { background: #fff; border-radius: 12px; padding: 16px; margin-bottom: 16px; box-shadow: 0 2px 12px rgba(0,0,0,0.08); }
+    ul { padding-left: 18px; }
+    li { margin-bottom: 6px; line-height: 1.6; }
+    .badge { display: inline-flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 999px; font-weight: 600; }
+    .score { background: ${getQualityScoreColor(Number(qualityScore))}; color: #fff; }
+    .meta { font-size: 13px; color: #4b5563; }
+</style>
+</head>
+<body>
+<h1>Token 閾值提醒</h1>
+<section>
+    <div class="badge score">品質評分：${qualityScore}</div>
+    <p class="meta">累積 Tokens：${safeTotal.toLocaleString()} / 閾值 ${cachedTokenThreshold.toLocaleString()}</p>
+    <p>${qualityFeedback}</p>
+</section>
+<section>
+    <h2>摘要</h2>
+    <p>${summary}</p>
+</section>
+<section>
+    <h2>短期記憶</h2>
+    <ul>
+        ${stmItems.map(item => `<li>${item.role === 'user' ? '使用者' : '助手'}：${item.content || ''}</li>`).join('') || '<li>尚無紀錄。</li>'}
+    </ul>
+</section>
+<section>
+    <h2>長期記憶要點</h2>
+    <ul>
+        ${ltmItems.map(item => `<li>${item.detail || item.title || ''}</li>`).join('') || '<li>尚無紀錄。</li>'}
+    </ul>
+</section>
+<section>
+    <h2>建議行動</h2>
+    <ul>
+        <li>在主視窗中建立新對話以避免上下文過長。</li>
+        <li>參考上述摘要與記憶，撰寫新的指令或需求。</li>
+        <li>如果需要，可調整 Token 閾值設定以符合工作流程。</li>
+    </ul>
+</section>
+</body>
+</html>`);
+        helperWindow.document.close();
+    } catch (error) {
+        console.warn('無法開啟 Token 提醒視窗:', error);
+    }
+}
+
+function openTokenHelperWindow() {
+    if (!conversationInsights) {
+        showNotification('目前尚未產生可整理的對話記憶。', 'info');
+        return;
+    }
+    spawnTokenHelperWindow(tokenUsageSnapshot.total_token_count, false);
+}
+
+function dismissTokenBanner() {
+    const banner = document.getElementById('tokenThresholdBanner');
+    if (banner) {
+        banner.classList.remove('active');
+    }
 }
 
 function useSuggestion(text) {
@@ -486,8 +1095,9 @@ async function createNewProject() {
     try {
         const response = await fetch('/select-folder');
         const result = await response.json();
-        
+
         if (result.success && result.path) {
+            cancelConversationRefreshTimer();
             currentProjectDir = result.path;
             isIterationMode = false;
             
@@ -531,8 +1141,9 @@ async function selectExistingFolder() {
     try {
         const response = await fetch('/select-folder');
         const result = await response.json();
-        
+
         if (result.success && result.path) {
+            cancelConversationRefreshTimer();
             currentProjectDir = result.path;
             isIterationMode = true;
             
@@ -652,6 +1263,7 @@ function getTimeAgo(dateString) {
 }
 
 async function selectProject(project) {
+    cancelConversationRefreshTimer();
     currentProjectDir = project.path;
     isIterationMode = true;
     
@@ -711,17 +1323,11 @@ async function loadExistingProject(projectDir) {
             document.getElementById('currentProjectName').textContent = currentProject.name;
             displayProjectStructure(result.project_info.files);
             
-            if (result.conversation && result.conversation.messages) {
-                const container = document.getElementById('resultsContainer');
-                if (container) {
-                    container.innerHTML = '';
-                    
-                    for (const msg of result.conversation.messages) {
-                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output);
-                    }
-                }
-            }
-            
+            renderConversationHistory(result.conversation);
+
+            updateConversationInsights(result.conversation);
+            checkTokenThreshold(result.conversation?.token_usage, { skipAuto: true });
+
             return true;
         } else {
             return false;
@@ -819,7 +1425,8 @@ function resetToHome() {
     if (!confirm('確定要回到初始介面嗎？當前專案選擇將被清除。')) {
         return;
     }
-    
+
+    cancelConversationRefreshTimer();
     currentProjectDir = null;
     currentProject = null;
     isIterationMode = false;
@@ -835,10 +1442,20 @@ function resetToHome() {
     document.querySelectorAll('.project-item').forEach(item => {
         item.classList.remove('active');
     });
-    
+
     updateFilesPreview();
     updateAttachedFilesDisplay();
-    
+
+    updateConversationInsights(null);
+    dismissTokenBanner();
+    tokenUsageSnapshot = {
+        prompt_token_count: 0,
+        candidates_token_count: 0,
+        thoughts_token_count: 0,
+        total_token_count: 0
+    };
+    tokenThresholdTriggered = false;
+
     showNotification('已回到初始介面', 'info');
 }
 
@@ -867,7 +1484,13 @@ async function loadSettings() {
         document.getElementById('safetyHateSpeech').value = safetySettings.HARM_CATEGORY_HATE_SPEECH || 'BLOCK_MEDIUM_AND_ABOVE';
         document.getElementById('safetySexuallyExplicit').value = safetySettings.HARM_CATEGORY_SEXUALLY_EXPLICIT || 'BLOCK_MEDIUM_AND_ABOVE';
         document.getElementById('safetyDangerousContent').value = safetySettings.HARM_CATEGORY_DANGEROUS_CONTENT || 'BLOCK_MEDIUM_AND_ABOVE';
-        
+
+        const automationSettings = config.automation_settings || {};
+        const tokenField = document.getElementById('tokenThreshold');
+        const monitorField = document.getElementById('monitorInterval');
+        if (tokenField) tokenField.value = automationSettings.token_reset_threshold || 120000;
+        if (monitorField) monitorField.value = automationSettings.monitor_interval || 5;
+
         updateSliderValue('thinkingBudget');
         updateSliderValue('temperature');
         updateSliderValue('topP');
@@ -911,7 +1534,8 @@ async function saveSettings() {
                 auto_error_fix: false,
                 auto_optimize: false,
                 auto_test: false,
-                monitor_interval: 5
+                monitor_interval: parseInt(document.getElementById('monitorInterval').value) || 5,
+                token_reset_threshold: parseInt(document.getElementById('tokenThreshold').value) || 120000
             }
         };
 

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -860,8 +860,92 @@ body {
     font-size: 14px;
     line-height: 1.6;
     color: var(--text-primary);
-    white-space: pre-wrap;
     word-wrap: break-word;
+}
+
+.message-text {
+    white-space: pre-wrap;
+    font-family: inherit;
+}
+
+.message-attachments {
+    margin-top: 12px;
+    padding: 10px 12px;
+    background: var(--bg-primary);
+    border: 1px dashed var(--border-color);
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.attachment-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.attachment-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.attachment-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: var(--bg-secondary);
+    font-size: 12px;
+    color: var(--text-primary);
+    border: 1px solid var(--border-light);
+}
+
+.attachment-icon {
+    font-size: 14px;
+}
+
+.attachment-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    line-height: 1.4;
+}
+
+.attachment-name {
+    font-weight: 500;
+    word-break: break-all;
+}
+
+.attachment-badge {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: rgba(16, 163, 127, 0.12);
+    color: var(--primary-color);
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.attachment-note {
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.attachment-clickable {
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.attachment-clickable:hover {
+    background: var(--bg-primary);
+    border-color: var(--primary-color);
 }
 
 .token-usage {
@@ -925,6 +1009,174 @@ body {
     line-height: 1.4;
     white-space: pre-wrap;
     word-wrap: break-word;
+}
+
+/* =================================== */
+/* 對話摘要與記憶面板 */
+/* =================================== */
+.conversation-insights {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    border-radius: 16px;
+    padding: 20px;
+    margin: 0 auto 20px;
+    max-width: 900px;
+    box-shadow: var(--shadow-sm);
+}
+
+.insights-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+    margin-bottom: 16px;
+}
+
+.insights-header h3 {
+    font-size: 18px;
+    margin-bottom: 6px;
+}
+
+.insight-summary {
+    font-size: 14px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.quality-score-badge {
+    min-width: 68px;
+    padding: 6px 12px;
+    border-radius: 12px;
+    text-align: center;
+    font-weight: 700;
+    color: white;
+    background: var(--primary-color);
+    box-shadow: var(--shadow-sm);
+}
+
+.insight-body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.insight-column h4 {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.memory-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.memory-list li {
+    background: var(--bg-secondary);
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-size: 13px;
+    color: var(--text-primary);
+    border: 1px solid var(--border-light);
+}
+
+.memory-tag {
+    display: inline-block;
+    padding: 2px 6px;
+    background: rgba(16, 163, 127, 0.12);
+    color: var(--primary-color);
+    border-radius: 6px;
+    font-size: 11px;
+    margin-right: 6px;
+}
+
+.memory-notes {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-primary);
+    padding: 10px 12px;
+    background: var(--bg-secondary);
+    border-radius: 10px;
+    border: 1px solid var(--border-light);
+}
+
+.token-usage-footer {
+    margin-top: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.token-chip {
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: var(--bg-secondary);
+    font-size: 12px;
+    color: var(--text-secondary);
+    border: 1px solid var(--border-light);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.token-chip strong {
+    color: var(--text-primary);
+}
+
+/* =================================== */
+/* Token 閾值提醒橫幅 */
+/* =================================== */
+.token-threshold-banner {
+    display: none;
+    background: #fef3c7;
+    border: 1px solid #fcd34d;
+    color: #92400e;
+    padding: 12px 16px;
+    border-radius: 12px;
+    margin: 12px auto;
+    max-width: 900px;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.token-threshold-banner.active {
+    display: flex;
+}
+
+.token-banner-icon {
+    font-size: 20px;
+}
+
+.token-banner-text {
+    flex: 1;
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.token-banner-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.banner-btn {
+    border: none;
+    background: var(--primary-color);
+    color: white;
+    padding: 6px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.banner-btn.secondary {
+    background: transparent;
+    color: #92400e;
+    border: 1px solid #fcd34d;
 }
 
 /* =================================== */
@@ -1071,6 +1323,29 @@ body {
     font-size: 11px;
     color: var(--text-secondary);
     margin-top: 6px;
+}
+
+.number-input-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.number-input-group .form-input {
+    flex: 1;
+}
+
+.input-suffix {
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.form-hint {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 6px;
+    line-height: 1.5;
 }
 
 .slider {


### PR DESCRIPTION
## Summary
- enrich run-process responses with attachment metadata so conversation history carries generated files, screenshots, and quality context
- refresh the front-end conversation view immediately after new messages and surface attachments, memory insights, and token thresholds without reloading
- style attachment chips with descriptive badges and clickable links to improve visibility of uploaded assets and terminal outputs

## Testing
- python -m compileall app.py static/app.js

------
https://chatgpt.com/codex/tasks/task_e_68e8a7c59df083299207d0a53121e69c