### PR TITLE
新增長短期記憶系統與歷史摘要儀表板

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -69,12 +69,15 @@ SCREENSHOT_DIR = CONFIG_DIR / 'screenshots'
 LOG_DIR = CONFIG_DIR / 'logs'
 PROJECTS_DIR = CONFIG_DIR / 'projects'
 CONVERSATIONS_DIR = CONFIG_DIR / 'conversations'
+MEMORY_DIR = CONFIG_DIR / 'memory'
 PROJECT_LIST_FILE = CONFIG_DIR / 'project_list.json'
+
+DEFAULT_MEMORY_TOKEN_THRESHOLD = 6000
 
 # 確保所有目錄都存在，並處理錯誤
 def ensure_directories():
     """確保所有必要的目錄都存在"""
-    directories = [CONFIG_DIR, SCREENSHOT_DIR, LOG_DIR, PROJECTS_DIR, CONVERSATIONS_DIR]
+    directories = [CONFIG_DIR, SCREENSHOT_DIR, LOG_DIR, PROJECTS_DIR, CONVERSATIONS_DIR, MEMORY_DIR]
     
     for directory in directories:
         try:
@@ -211,6 +214,61 @@ class ProcessResult:
     is_iteration: bool = False
     usage_metadata: Optional[Dict] = None
     terminal_output: str = ""
+    memory_snapshot: Optional[Dict] = None
+    token_threshold_reached: bool = False
+
+
+@dataclass
+class MemoryWindow:
+    """短期記憶窗口"""
+    id: str
+    created_at: str
+    updated_at: str
+    summary: str = ""
+    message_count: int = 0
+    token_usage: Dict[str, int] = field(default_factory=lambda: {
+        'prompt': 0,
+        'completion': 0,
+        'thought': 0,
+        'total': 0
+    })
+    notes: List[str] = field(default_factory=list)
+
+
+@dataclass
+class LongTermMemoryItem:
+    """長期記憶項目"""
+    memory_id: str
+    title: str
+    summary: str
+    detail: str
+    created_at: str
+    updated_at: str
+    tags: List[str] = field(default_factory=list)
+    references: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ProjectMemory:
+    """專案記憶資料結構"""
+    project_dir: str
+    project_name: str
+    created_at: str
+    updated_at: str
+    token_threshold: int = DEFAULT_MEMORY_TOKEN_THRESHOLD
+    windows: List[MemoryWindow] = field(default_factory=list)
+    long_term_memory: List[LongTermMemoryItem] = field(default_factory=list)
+    core_summary: Dict[str, Any] = field(default_factory=lambda: {
+        'latest': '',
+        'updated_at': ''
+    })
+    stats: Dict[str, Any] = field(default_factory=lambda: {
+        'total_messages': 0,
+        'total_tokens': 0,
+        'total_prompt_tokens': 0,
+        'total_completion_tokens': 0,
+        'total_thought_tokens': 0
+    })
 
 # ============================================
 # JSON Schema 定義 - 繁體中文化
@@ -548,6 +606,230 @@ class ConversationManager:
         except Exception as e:
             logger.error(f"刪除對話檔案失敗: {e}")
             return False
+
+
+class MemoryManager:
+    """長短期記憶管理器"""
+
+    @staticmethod
+    def get_memory_file(project_dir: str) -> Path:
+        import hashlib
+        project_hash = hashlib.md5(project_dir.encode()).hexdigest()
+        return MEMORY_DIR / f"memory_{project_hash}.json"
+
+    @staticmethod
+    def _dict_to_memory(data: Dict[str, Any]) -> ProjectMemory:
+        windows = []
+        for window_data in data.get('windows', []):
+            token_usage = window_data.get('token_usage') or {}
+            normalized_usage = {
+                'prompt': int(token_usage.get('prompt', 0)),
+                'completion': int(token_usage.get('completion', 0)),
+                'thought': int(token_usage.get('thought', 0)),
+                'total': int(token_usage.get('total', 0))
+            }
+            windows.append(MemoryWindow(
+                id=window_data.get('id', f"win-{int(time.time()*1000)}"),
+                created_at=window_data.get('created_at', datetime.now().isoformat()),
+                updated_at=window_data.get('updated_at', datetime.now().isoformat()),
+                summary=window_data.get('summary', ''),
+                message_count=int(window_data.get('message_count', 0)),
+                token_usage=normalized_usage,
+                notes=window_data.get('notes', [])
+            ))
+
+        ltms = []
+        for item in data.get('long_term_memory', []):
+            ltms.append(LongTermMemoryItem(
+                memory_id=item.get('memory_id', f"ltm-{int(time.time()*1000)}"),
+                title=item.get('title', '未命名記憶'),
+                summary=item.get('summary', ''),
+                detail=item.get('detail', ''),
+                created_at=item.get('created_at', datetime.now().isoformat()),
+                updated_at=item.get('updated_at', datetime.now().isoformat()),
+                tags=item.get('tags', []),
+                references=item.get('references', [])
+            ))
+
+        core_summary = data.get('core_summary') or {'latest': '', 'updated_at': ''}
+        stats = data.get('stats') or {
+            'total_messages': 0,
+            'total_tokens': 0,
+            'total_prompt_tokens': 0,
+            'total_completion_tokens': 0,
+            'total_thought_tokens': 0
+        }
+
+        return ProjectMemory(
+            project_dir=data.get('project_dir', ''),
+            project_name=data.get('project_name', ''),
+            created_at=data.get('created_at', datetime.now().isoformat()),
+            updated_at=data.get('updated_at', datetime.now().isoformat()),
+            token_threshold=int(data.get('token_threshold', DEFAULT_MEMORY_TOKEN_THRESHOLD)),
+            windows=windows,
+            long_term_memory=ltms,
+            core_summary=core_summary,
+            stats=stats
+        )
+
+    @staticmethod
+    def load_memory(project_dir: str, project_name: Optional[str] = None) -> ProjectMemory:
+        memory_file = MemoryManager.get_memory_file(project_dir)
+        if memory_file.exists():
+            try:
+                with open(memory_file, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                    memory = MemoryManager._dict_to_memory(data)
+                    if not memory.project_name and project_name:
+                        memory.project_name = project_name
+                    return memory
+            except Exception as e:
+                logger.error(f"讀取記憶檔案失敗: {e}")
+
+        now = datetime.now().isoformat()
+        memory = ProjectMemory(
+            project_dir=project_dir,
+            project_name=project_name or Path(project_dir).name,
+            created_at=now,
+            updated_at=now
+        )
+        MemoryManager.ensure_window(memory)
+        MemoryManager.save_memory(memory)
+        return memory
+
+    @staticmethod
+    def save_memory(memory: ProjectMemory) -> None:
+        try:
+            MEMORY_DIR.mkdir(parents=True, exist_ok=True)
+            memory.updated_at = datetime.now().isoformat()
+            with open(MemoryManager.get_memory_file(memory.project_dir), 'w', encoding='utf-8') as f:
+                json.dump(asdict(memory), f, indent=2, ensure_ascii=False)
+        except Exception as e:
+            logger.error(f"儲存記憶資料失敗: {e}")
+
+    @staticmethod
+    def ensure_window(memory: ProjectMemory) -> MemoryWindow:
+        if not memory.windows:
+            now = datetime.now().isoformat()
+            memory.windows.append(MemoryWindow(
+                id=f"win-{int(time.time()*1000)}",
+                created_at=now,
+                updated_at=now
+            ))
+        return memory.windows[-1]
+
+    @staticmethod
+    def generate_summary(messages: List[ConversationMessage], max_messages: int = 6, max_chars: int = 600) -> str:
+        if not messages:
+            return ''
+
+        selected_messages = messages[-max_messages:]
+        summary_lines = []
+        for msg in selected_messages:
+            role_label = '使用者' if msg.role == 'user' else '助手'
+            content = msg.content.strip().replace('\r', '')
+            if len(content) > 200:
+                content = content[:197] + '...'
+            summary_lines.append(f"{role_label}: {content}")
+
+        summary_text = '\n'.join(summary_lines)
+        if len(summary_text) > max_chars:
+            summary_text = summary_text[: max_chars - 3] + '...'
+        return summary_text
+
+    @staticmethod
+    def promote_to_long_term(memory: ProjectMemory, summary_text: str, notes: Optional[List[str]] = None) -> None:
+        if not summary_text:
+            return
+
+        now = datetime.now().isoformat()
+        title = summary_text.split('\n')[0][:60] if summary_text else '摘要'
+        memory.long_term_memory.append(LongTermMemoryItem(
+            memory_id=f"ltm-{int(time.time()*1000)}",
+            title=title,
+            summary=summary_text,
+            detail='\n'.join(notes or []),
+            created_at=now,
+            updated_at=now,
+            tags=['自動摘要'],
+            references=[]
+        ))
+
+    @staticmethod
+    def build_snapshot(memory: ProjectMemory) -> Dict[str, Any]:
+        current_window = MemoryManager.ensure_window(memory)
+        return {
+            'project_dir': memory.project_dir,
+            'project_name': memory.project_name,
+            'core_summary': memory.core_summary,
+            'current_window': asdict(current_window),
+            'long_term_memory': [asdict(item) for item in memory.long_term_memory],
+            'stats': memory.stats,
+            'token_threshold': memory.token_threshold,
+            'windows_count': len(memory.windows)
+        }
+
+    @staticmethod
+    def start_new_window(memory: ProjectMemory) -> MemoryWindow:
+        now = datetime.now().isoformat()
+        new_window = MemoryWindow(
+            id=f"win-{int(time.time()*1000)}",
+            created_at=now,
+            updated_at=now
+        )
+        memory.windows.append(new_window)
+        return new_window
+
+    @staticmethod
+    def update_after_interaction(
+        project_dir: str,
+        project_name: str,
+        usage_metadata: Optional[Dict[str, Any]],
+        conversation: ProjectConversation
+    ) -> Dict[str, Any]:
+        memory = MemoryManager.load_memory(project_dir, project_name)
+        window = MemoryManager.ensure_window(memory)
+
+        prompt_tokens = int((usage_metadata or {}).get('prompt_token_count', 0))
+        completion_tokens = int((usage_metadata or {}).get('candidates_token_count', 0))
+        thought_tokens = int((usage_metadata or {}).get('thoughts_token_count', 0))
+        total_tokens = int((usage_metadata or {}).get('total_token_count', prompt_tokens + completion_tokens + thought_tokens))
+
+        window.token_usage['prompt'] += prompt_tokens
+        window.token_usage['completion'] += completion_tokens
+        window.token_usage['thought'] += thought_tokens
+        window.token_usage['total'] += total_tokens
+
+        memory.stats['total_tokens'] += total_tokens
+        memory.stats['total_prompt_tokens'] += prompt_tokens
+        memory.stats['total_completion_tokens'] += completion_tokens
+        memory.stats['total_thought_tokens'] += thought_tokens
+        memory.stats['total_messages'] = len(conversation.messages)
+
+        summary_text = MemoryManager.generate_summary(conversation.messages)
+        if summary_text:
+            window.summary = summary_text
+            window.updated_at = datetime.now().isoformat()
+            memory.core_summary['latest'] = summary_text
+            memory.core_summary['updated_at'] = datetime.now().isoformat()
+
+        window.message_count = len(conversation.messages)
+
+        threshold_reached = window.token_usage['total'] >= memory.token_threshold or window.message_count >= 20
+
+        if threshold_reached:
+            MemoryManager.promote_to_long_term(memory, summary_text)
+            window.updated_at = datetime.now().isoformat()
+            MemoryManager.start_new_window(memory)
+
+        MemoryManager.save_memory(memory)
+
+        snapshot = MemoryManager.build_snapshot(memory)
+
+        return {
+            'snapshot': snapshot,
+            'threshold_reached': threshold_reached
+        }
 
 # ============================================
 # 專案管理模塊
@@ -2060,7 +2342,22 @@ class ProcessManager:
                 terminal_output=result.terminal_output,
                 usage_metadata=usage_metadata  # ⭐ 直接傳遞 usage_metadata
             )
-            
+
+            try:
+                memory_update = MemoryManager.update_after_interaction(
+                    final_project_dir,
+                    project.project_name,
+                    usage_metadata,
+                    ConversationManager.load_conversation(final_project_dir)
+                )
+                result.memory_snapshot = memory_update.get('snapshot')
+                result.token_threshold_reached = memory_update.get('threshold_reached', False)
+
+                if result.token_threshold_reached:
+                    logger.info("記憶窗口達到閾值，已建立新的短期記憶視窗")
+            except Exception as memory_error:
+                logger.error(f"更新記憶模塊失敗: {memory_error}")
+
         except Exception as e:
             result.error = str(e)
             logger.error(f"處理流程失敗: {e}")
@@ -2165,7 +2462,10 @@ def load_project():
         project_files = ProjectManager.load_project_files(project_dir)
         project_structure = ProjectManager.get_project_structure(project_dir)
         conversation = ConversationManager.load_conversation(project_dir)
-        
+        memory_snapshot = MemoryManager.build_snapshot(
+            MemoryManager.load_memory(project_dir, project_info.get('project_name'))
+        )
+
         # ⭐ 修復:正確序列化對話消息,保留 usage_metadata
         messages_data = []
         for msg in conversation.messages:
@@ -2190,7 +2490,8 @@ def load_project():
                 'messages': messages_data,
                 'created_at': conversation.created_at,
                 'updated_at': conversation.updated_at
-            }
+            },
+            'memory_snapshot': memory_snapshot
         })
         
     except Exception as e:
@@ -2238,6 +2539,20 @@ def get_conversation(project_dir):
             'success': False,
             'error': str(e)
         }), 500
+
+
+@app.route('/api/memory/<path:project_dir>', methods=['GET'])
+def get_memory_snapshot(project_dir):
+    """獲取專案記憶快照"""
+    try:
+        conversation = ConversationManager.load_conversation(project_dir)
+        project_name = conversation.project_name or Path(project_dir).name
+        memory = MemoryManager.load_memory(project_dir, project_name)
+        snapshot = MemoryManager.build_snapshot(memory)
+        return jsonify({'success': True, 'memory': snapshot})
+    except Exception as e:
+        logger.error(f"載入記憶資料失敗: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 @app.route('/api/projects', methods=['GET'])
 def get_projects():
@@ -2324,7 +2639,9 @@ def run_process():
             'screenshots': result.screenshots,
             'is_iteration': result.is_iteration,
             'usage_metadata': result.usage_metadata,
-            'terminal_output': result.terminal_output
+            'terminal_output': result.terminal_output,
+            'memory_snapshot': result.memory_snapshot,
+            'token_threshold_reached': result.token_threshold_reached
         }
         
         if result.project_data:

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -13,6 +13,9 @@ let allProjects = [];
 let modelConfig = null;
 let sidebarCollapsed = false;
 let MODEL_LIMITS = {};
+let lastUserMessageElement = null;
+let memorySnapshot = null;
+const DEFAULT_MEMORY_TOKEN_THRESHOLD = 6000;
 
 // ============================================
 // Loading Overlay 控制 - 修復版
@@ -36,6 +39,180 @@ function hideLoading() {
     const overlay = document.getElementById('loadingOverlay');
     if (overlay) {
         overlay.classList.remove('active');
+    }
+}
+
+// ============================================
+// 實用工具函式
+// ============================================
+
+function escapeHtml(text = '') {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function formatMultilineText(text = '') {
+    return escapeHtml(text).replace(/\n/g, '<br>');
+}
+
+function getFileIcon(type = '') {
+    const lowered = (type || '').toLowerCase();
+    if (lowered.includes('python') || lowered.endsWith('.py')) return '🐍';
+    if (lowered.includes('javascript') || lowered.endsWith('.js')) return '🟨';
+    if (lowered.includes('html')) return '🌐';
+    if (lowered.includes('css')) return '🎨';
+    if (lowered.includes('json')) return '🧾';
+    if (lowered.includes('pdf')) return '📕';
+    if (lowered.includes('image') || /\.(png|jpg|jpeg|gif|bmp)$/i.test(lowered)) return '🖼️';
+    if (lowered.includes('text') || /\.(txt|md)$/i.test(lowered)) return '📄';
+    return '📁';
+}
+
+function createAttachmentElement(file) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'message-attachment-item';
+    const icon = document.createElement('span');
+    icon.className = 'message-attachment-icon';
+    icon.textContent = getFileIcon(file?.type || file?.name || '');
+    const name = document.createElement('span');
+    name.className = 'message-attachment-name';
+    name.textContent = file?.name || '附件';
+    wrapper.appendChild(icon);
+    wrapper.appendChild(name);
+    return wrapper;
+}
+
+function updateMessageTerminalOutput(messageElement, terminalOutput) {
+    if (!messageElement || !terminalOutput) return;
+    let terminalSection = messageElement.querySelector('.terminal-output-section');
+    if (!terminalSection) {
+        terminalSection = document.createElement('div');
+        terminalSection.className = 'terminal-output-section';
+        terminalSection.innerHTML = `
+            <div class="terminal-header">
+                <span class="terminal-title">Terminal 輸出</span>
+            </div>
+            <div class="terminal-body selectable"></div>
+        `;
+        messageElement.appendChild(terminalSection);
+    }
+    const body = terminalSection.querySelector('.terminal-body');
+    if (body) {
+        body.innerHTML = formatMultilineText(terminalOutput);
+    }
+}
+
+function renderAttachments(container, attachments = []) {
+    if (!container || !attachments || attachments.length === 0) return;
+    attachments.forEach(file => {
+        container.appendChild(createAttachmentElement(file));
+    });
+}
+
+function formatDisplayTime(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return date.toLocaleString('zh-TW', { hour12: false });
+}
+
+async function refreshMemorySnapshot() {
+    if (!currentProjectDir) return;
+    try {
+        const response = await fetch(`/api/memory/${encodeURIComponent(currentProjectDir)}`);
+        const data = await response.json();
+        if (data.success && data.memory) {
+            updateMemoryDashboard(data.memory, false);
+        }
+    } catch (error) {
+        console.warn('刷新記憶資料失敗', error);
+    }
+}
+
+function updateMemoryDashboard(snapshot, highlightThreshold = false) {
+    if (!snapshot) return;
+    memorySnapshot = snapshot;
+
+    const dashboard = document.getElementById('memoryDashboard');
+    if (!dashboard) return;
+    dashboard.style.display = 'block';
+
+    const summaryEl = document.getElementById('memorySummaryText');
+    const summaryText = snapshot.core_summary?.latest;
+    if (summaryEl) {
+        summaryEl.innerHTML = summaryText ? formatMultilineText(summaryText) : '尚無摘要';
+    }
+
+    const thresholdBadge = document.getElementById('memoryThresholdBadge');
+    if (thresholdBadge) {
+        thresholdBadge.textContent = `Token 閾值 ${snapshot.token_threshold || DEFAULT_MEMORY_TOKEN_THRESHOLD}`;
+    }
+
+    const currentTokens = snapshot.current_window?.token_usage?.total || 0;
+    const currentPromptTokens = snapshot.current_window?.token_usage?.prompt || 0;
+    const currentCompletionTokens = snapshot.current_window?.token_usage?.completion || 0;
+    const totalTokens = snapshot.stats?.total_tokens || 0;
+    const totalMessages = snapshot.stats?.total_messages || 0;
+
+    const currentTokensEl = document.getElementById('memoryCurrentTokens');
+    if (currentTokensEl) currentTokensEl.textContent = currentTokens.toLocaleString();
+    const promptTokensEl = document.getElementById('memoryPromptTokens');
+    if (promptTokensEl) promptTokensEl.textContent = currentPromptTokens.toLocaleString();
+    const completionTokensEl = document.getElementById('memoryCompletionTokens');
+    if (completionTokensEl) completionTokensEl.textContent = currentCompletionTokens.toLocaleString();
+    const totalTokensEl = document.getElementById('memoryTotalTokens');
+    if (totalTokensEl) totalTokensEl.textContent = totalTokens.toLocaleString();
+    const totalMessagesEl = document.getElementById('memoryTotalMessages');
+    if (totalMessagesEl) totalMessagesEl.textContent = totalMessages.toLocaleString();
+
+    const windowInfoEl = document.getElementById('memoryWindowInfo');
+    if (windowInfoEl) {
+        const count = snapshot.windows_count || 1;
+        const updated = snapshot.current_window?.updated_at;
+        windowInfoEl.textContent = `視窗 ${count}｜更新 ${formatDisplayTime(updated)}`;
+    }
+
+    const longTermList = document.getElementById('memoryLongTermList');
+    if (longTermList) {
+        longTermList.innerHTML = '';
+        const items = snapshot.long_term_memory || [];
+        if (items.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'memory-empty';
+            empty.textContent = '尚無長期記憶紀錄';
+            longTermList.appendChild(empty);
+        } else {
+            items.slice(-10).reverse().forEach(item => {
+                const card = document.createElement('div');
+                card.className = 'memory-item';
+                const title = document.createElement('div');
+                title.className = 'memory-item-title';
+                title.textContent = item.title || '摘要';
+                const summary = document.createElement('div');
+                summary.className = 'memory-item-summary';
+                summary.innerHTML = formatMultilineText(item.summary || '');
+                const meta = document.createElement('div');
+                meta.className = 'memory-item-meta';
+                meta.textContent = `更新於 ${formatDisplayTime(item.updated_at)}`;
+                card.appendChild(title);
+                card.appendChild(summary);
+                card.appendChild(meta);
+                longTermList.appendChild(card);
+            });
+        }
+    }
+
+    const nearingThreshold = currentTokens >= (snapshot.token_threshold || DEFAULT_MEMORY_TOKEN_THRESHOLD) * 0.9;
+    if (highlightThreshold || nearingThreshold) {
+        dashboard.classList.add('memory-warning');
+    } else {
+        dashboard.classList.remove('memory-warning');
     }
 }
 
@@ -327,7 +504,8 @@ async function handleSubmit() {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
 
-    addMessage('user', prompt);
+    const attachmentsForMessage = uploadedFiles.map(file => ({ name: file.name, type: file.type }));
+    lastUserMessageElement = addMessage('user', prompt, null, null, attachmentsForMessage);
 
     input.value = '';
     updateSubmitButton();
@@ -356,7 +534,21 @@ async function handleSubmit() {
 
         if (result.success) {
             addMessage('assistant', result.output, result.usage_metadata, result.terminal_output);
-            
+
+            if (result.terminal_output && lastUserMessageElement) {
+                updateMessageTerminalOutput(lastUserMessageElement, result.terminal_output);
+            }
+
+            if (result.memory_snapshot) {
+                updateMemoryDashboard(result.memory_snapshot, result.token_threshold_reached === true);
+            } else if (currentProjectDir) {
+                refreshMemorySnapshot();
+            }
+
+            if (result.token_threshold_reached) {
+                showNotification('Token 使用量已達預設閾值，已自動啟動新的記憶視窗。', 'warning');
+            }
+
             if (result.project) {
                 currentProject = result.project;
                 if (result.ai_response_json) {
@@ -394,13 +586,14 @@ async function handleSubmit() {
         showNotification(`連接錯誤：${error}`, 'error');
     } finally {
         hideLoading();
+        lastUserMessageElement = null;
     }
 }
 
-function addMessage(role, content, usageMetadata = null, terminalOutput = null) {
+function addMessage(role, content, usageMetadata = null, terminalOutput = null, attachments = []) {
     const container = document.getElementById('resultsContainer');
     if (!container) return;
-    
+
     const message = document.createElement('div');
     message.className = `result-message ${role} selectable`;
 
@@ -420,24 +613,23 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
 
     const messageContent = document.createElement('div');
     messageContent.className = 'message-content selectable';
-    messageContent.textContent = content;
+    messageContent.innerHTML = formatMultilineText(content || '');
 
     message.appendChild(header);
     message.appendChild(messageContent);
-    
+
+    if (attachments && attachments.length) {
+        const attachmentsSection = document.createElement('div');
+        attachmentsSection.className = 'message-attachments';
+        renderAttachments(attachmentsSection, attachments);
+        message.appendChild(attachmentsSection);
+    }
+
     // ✅ Terminal輸出只顯示在用戶消息中
     if (role === 'user' && terminalOutput && terminalOutput.trim()) {
-        const terminalSection = document.createElement('div');
-        terminalSection.className = 'terminal-output-section';
-        terminalSection.innerHTML = `
-            <div class="terminal-header">
-                <span class="terminal-title">Terminal 輸出</span>
-            </div>
-            <div class="terminal-body selectable">${terminalOutput}</div>
-        `;
-        message.appendChild(terminalSection);
+        updateMessageTerminalOutput(message, terminalOutput);
     }
-    
+
     // Token使用統計只顯示在AI回應中
     if (role === 'assistant' && usageMetadata && typeof usageMetadata === 'object') {
         const tokenUsage = document.createElement('div');
@@ -465,6 +657,7 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
     
     container.appendChild(message);
     message.scrollIntoView({ behavior: 'smooth' });
+    return message;
 }
 
 function useSuggestion(text) {
@@ -715,13 +908,19 @@ async function loadExistingProject(projectDir) {
                 const container = document.getElementById('resultsContainer');
                 if (container) {
                     container.innerHTML = '';
-                    
+
                     for (const msg of result.conversation.messages) {
-                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output);
+                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output, msg.files || []);
                     }
                 }
             }
-            
+
+            if (result.memory_snapshot) {
+                updateMemoryDashboard(result.memory_snapshot, false);
+            } else if (projectDir) {
+                refreshMemorySnapshot();
+            }
+
             return true;
         } else {
             return false;
@@ -835,10 +1034,32 @@ function resetToHome() {
     document.querySelectorAll('.project-item').forEach(item => {
         item.classList.remove('active');
     });
-    
+
     updateFilesPreview();
     updateAttachedFilesDisplay();
-    
+
+    const memoryDashboard = document.getElementById('memoryDashboard');
+    if (memoryDashboard) {
+        memoryDashboard.style.display = 'none';
+    }
+    const memorySummary = document.getElementById('memorySummaryText');
+    if (memorySummary) {
+        memorySummary.textContent = '尚無摘要';
+    }
+    const memoryCurrentTokens = document.getElementById('memoryCurrentTokens');
+    if (memoryCurrentTokens) {
+        memoryCurrentTokens.textContent = '0';
+    }
+    const memoryTotalTokens = document.getElementById('memoryTotalTokens');
+    if (memoryTotalTokens) {
+        memoryTotalTokens.textContent = '0';
+    }
+    const longTermList = document.getElementById('memoryLongTermList');
+    if (longTermList) {
+        longTermList.innerHTML = '';
+    }
+    memorySnapshot = null;
+
     showNotification('已回到初始介面', 'info');
 }
 

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -864,6 +864,36 @@ body {
     word-wrap: break-word;
 }
 
+.message-attachments {
+    margin-top: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.message-attachment-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--text-primary);
+    max-width: 240px;
+}
+
+.message-attachment-icon {
+    font-size: 14px;
+}
+
+.message-attachment-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .token-usage {
     display: flex;
     gap: 16px;
@@ -1311,6 +1341,176 @@ input[type="file"] {
 }
 
 /* =================================== */
+/* 記憶儀表板 */
+/* =================================== */
+.memory-dashboard {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-light);
+    border-radius: 14px;
+    padding: 18px;
+    margin-bottom: 20px;
+    display: none;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.15);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.memory-dashboard.memory-warning {
+    border-color: #f97316;
+    box-shadow: 0 12px 36px rgba(249, 115, 22, 0.25);
+}
+
+.memory-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.memory-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.memory-window-info {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 4px;
+}
+
+.memory-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.memory-threshold {
+    font-size: 12px;
+    color: var(--text-secondary);
+    background: var(--bg-primary);
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--border-light);
+}
+
+.memory-refresh-btn {
+    background: var(--primary-color);
+    color: #ffffff;
+    border: none;
+    border-radius: 999px;
+    padding: 6px 16px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.memory-refresh-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(16, 163, 127, 0.3);
+}
+
+.memory-summary-text {
+    margin-top: 14px;
+    background: var(--bg-primary);
+    border-radius: 10px;
+    border: 1px solid var(--border-light);
+    padding: 14px;
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--text-primary);
+}
+
+.memory-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+    margin-top: 16px;
+}
+
+.memory-stat {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    border-radius: 10px;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.memory-stat-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-stat-value {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.memory-long-term-section {
+    margin-top: 18px;
+}
+
+.memory-long-term-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-bottom: 10px;
+    font-weight: 600;
+}
+
+.memory-long-term-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.memory-item {
+    border: 1px solid var(--border-light);
+    border-radius: 10px;
+    padding: 14px;
+    background: var(--bg-primary);
+    transition: border-color 0.2s ease;
+}
+
+.memory-item:hover {
+    border-color: var(--primary-color);
+}
+
+.memory-item-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 6px;
+}
+
+.memory-item-summary {
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.memory-item-meta {
+    margin-top: 8px;
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.memory-empty {
+    font-size: 12px;
+    color: var(--text-secondary);
+    background: var(--bg-primary);
+    border: 1px dashed var(--border-light);
+    border-radius: 10px;
+    padding: 14px;
+    text-align: center;
+}
+
+/* =================================== */
 /* 響應式設計 */
 /* =================================== */
 @media (max-width: 768px) {
@@ -1318,33 +1518,15 @@ input[type="file"] {
         width: 100%;
         transform: translateX(-100%);
     }
-    
+
     .main-content {
         margin-left: 0;
     }
-    
+
     .project-panel {
         right: 12px;
     }
-    
-    .project-panel-content {
-        width: calc(100vw - 24px);
-    }
-}
-@media (max-width: 768px) {
-    .sidebar {
-        width: 100%;
-        transform: translateX(-100%);
-    }
-    
-    .main-content {
-        margin-left: 0;
-    }
-    
-    .project-panel {
-        right: 12px;
-    }
-    
+
     .project-panel-content {
         width: calc(100vw - 24px);
     }

--- a/vscode_controller_project3-1/templates/index.html
+++ b/vscode_controller_project3-1/templates/index.html
@@ -179,6 +179,48 @@
                 </div>
             </div>
 
+            <div class="memory-dashboard" id="memoryDashboard" style="display: none;">
+                <div class="memory-header">
+                    <div>
+                        <div class="memory-title">核心記憶總結</div>
+                        <div class="memory-window-info" id="memoryWindowInfo"></div>
+                    </div>
+                    <div class="memory-header-actions">
+                        <span class="memory-threshold" id="memoryThresholdBadge">Token 閾值 6000</span>
+                        <button class="memory-refresh-btn" onclick="refreshMemorySnapshot()">刷新</button>
+                    </div>
+                </div>
+                <div class="memory-summary-text" id="memorySummaryText">尚無摘要</div>
+                <div class="memory-stats-grid">
+                    <div class="memory-stat">
+                        <span class="memory-stat-label">當前 Token</span>
+                        <span class="memory-stat-value" id="memoryCurrentTokens">0</span>
+                    </div>
+                    <div class="memory-stat">
+                        <span class="memory-stat-label">提示 Token</span>
+                        <span class="memory-stat-value" id="memoryPromptTokens">0</span>
+                    </div>
+                    <div class="memory-stat">
+                        <span class="memory-stat-label">回應 Token</span>
+                        <span class="memory-stat-value" id="memoryCompletionTokens">0</span>
+                    </div>
+                    <div class="memory-stat">
+                        <span class="memory-stat-label">累計 Token</span>
+                        <span class="memory-stat-value" id="memoryTotalTokens">0</span>
+                    </div>
+                    <div class="memory-stat">
+                        <span class="memory-stat-label">累計訊息</span>
+                        <span class="memory-stat-value" id="memoryTotalMessages">0</span>
+                    </div>
+                </div>
+                <div class="memory-long-term-section">
+                    <div class="memory-long-term-header">
+                        <span>長期記憶</span>
+                    </div>
+                    <div class="memory-long-term-list" id="memoryLongTermList"></div>
+                </div>
+            </div>
+
             <div class="results-container" id="resultsContainer" style="display: none;"></div>
         </div>
 


### PR DESCRIPTION
## Summary
- 建立 MemoryManager 模組，支援歷史摘要、Token 閾值新視窗與長期記憶 JSON 結構，並將快照回傳 API
- 前端即時顯示使用者附件、Terminal 輸出與長短期記憶儀表板，同步支援記憶刷新與閾值警示
- 新增附件與記憶儀表板樣式，讓記憶資訊與附件呈現更清晰

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68e8a7c9fe14832990cbb6518f11d56c