### PR TITLE
Add project memory system with UI panel and attachment visibility

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -17,6 +17,7 @@ import json
 import platform
 import logging
 import queue
+import copy
 from typing import Dict, List, Optional, Tuple, Any
 from datetime import datetime
 from pathlib import Path
@@ -69,12 +70,13 @@ SCREENSHOT_DIR = CONFIG_DIR / 'screenshots'
 LOG_DIR = CONFIG_DIR / 'logs'
 PROJECTS_DIR = CONFIG_DIR / 'projects'
 CONVERSATIONS_DIR = CONFIG_DIR / 'conversations'
+MEMORY_DIR = CONFIG_DIR / 'memory'
 PROJECT_LIST_FILE = CONFIG_DIR / 'project_list.json'
 
 # 確保所有目錄都存在，並處理錯誤
 def ensure_directories():
     """確保所有必要的目錄都存在"""
-    directories = [CONFIG_DIR, SCREENSHOT_DIR, LOG_DIR, PROJECTS_DIR, CONVERSATIONS_DIR]
+    directories = [CONFIG_DIR, SCREENSHOT_DIR, LOG_DIR, PROJECTS_DIR, CONVERSATIONS_DIR, MEMORY_DIR]
     
     for directory in directories:
         try:
@@ -211,6 +213,7 @@ class ProcessResult:
     is_iteration: bool = False
     usage_metadata: Optional[Dict] = None
     terminal_output: str = ""
+    final_project_dir: Optional[str] = None
 
 # ============================================
 # JSON Schema 定義 - 繁體中文化
@@ -550,6 +553,191 @@ class ConversationManager:
             return False
 
 # ============================================
+# 記憶系統管理模塊
+# ============================================
+
+class MemoryManager:
+    """長短期記憶與評分管理器"""
+
+    @staticmethod
+    def get_memory_file(project_dir: str) -> Path:
+        import hashlib
+        project_hash = hashlib.md5(project_dir.encode()).hexdigest()
+        return MEMORY_DIR / f"memory_{project_hash}.json"
+
+    @staticmethod
+    def _default_goals() -> List[Dict]:
+        return [
+            {"步驟": 1, "任務": "蒐集需求與建立環境", "狀態": "未開始", "是否為當前任務": True},
+            {"步驟": 2, "任務": "產出或更新核心功能", "狀態": "未開始", "是否為當前任務": False},
+            {"步驟": 3, "任務": "測試與驗證成果品質", "狀態": "未開始", "是否為當前任務": False},
+            {"步驟": 4, "任務": "整理文件並準備交付", "狀態": "未開始", "是否為當前任務": False}
+        ]
+
+    @staticmethod
+    def default_memory(project_dir: str, project_name: Optional[str] = None) -> Dict:
+        name = project_name or Path(project_dir).name
+        return {
+            "評分": 75,
+            "內容評價": "尚未產生任何 AI 回覆，等待首次互動建立基礎資料。",
+            "扣分原因": "無",
+            "改進建議": "請提交需求以建立記憶與任務追蹤。",
+            "核心記憶模塊": {
+                "專案總結": f"{name} 專案尚未建立詳細摘要。",
+                "短期記憶": "尚無近期互動記錄。",
+                "長期記憶": "尚未累積長期經驗。",
+                "專案目標": MemoryManager._default_goals()
+            },
+            "_meta": {
+                "history": [],
+                "long_term_notes": []
+            }
+        }
+
+    @staticmethod
+    def _sanitize(memory: Dict) -> Dict:
+        sanitized = copy.deepcopy(memory)
+        sanitized.pop('_meta', None)
+        return sanitized
+
+    @staticmethod
+    def load(project_dir: str, project_name: Optional[str] = None, raw: bool = False) -> Dict:
+        memory_file = MemoryManager.get_memory_file(project_dir)
+
+        if not memory_file.exists():
+            memory = MemoryManager.default_memory(project_dir, project_name)
+            MemoryManager.save(project_dir, memory)
+            return memory if raw else MemoryManager._sanitize(memory)
+
+        try:
+            with open(memory_file, 'r', encoding='utf-8') as f:
+                memory = json.load(f)
+        except Exception as e:
+            logger.error(f"讀取記憶檔案失敗: {e}")
+            memory = MemoryManager.default_memory(project_dir, project_name)
+
+        if '_meta' not in memory:
+            memory['_meta'] = {"history": [], "long_term_notes": []}
+
+        return memory if raw else MemoryManager._sanitize(memory)
+
+    @staticmethod
+    def save(project_dir: str, memory: Dict) -> None:
+        memory_file = MemoryManager.get_memory_file(project_dir)
+        with open(memory_file, 'w', encoding='utf-8') as f:
+            json.dump(memory, f, indent=2, ensure_ascii=False)
+
+    @staticmethod
+    def _truncate(text: str, length: int = 60) -> str:
+        if len(text) <= length:
+            return text
+        return text[:length - 1] + '…'
+
+    @staticmethod
+    def _set_goal_status(goals: List[Dict], step: int, status: str) -> None:
+        for goal in goals:
+            if goal.get('步驟') == step:
+                goal['狀態'] = status
+
+    @staticmethod
+    def _set_current_goal(goals: List[Dict], step: int) -> None:
+        for goal in goals:
+            goal['是否為當前任務'] = goal.get('步驟') == step
+
+    @staticmethod
+    def update_after_interaction(project_dir: str, user_prompt: str, result: ProcessResult) -> Dict:
+        project_name = None
+        project_description = None
+
+        if result.project_data:
+            project_name = result.project_data.project_name
+            project_description = result.project_data.description
+        else:
+            project_info = ProjectManager.load_project_info(project_dir)
+            if project_info:
+                project_name = project_info.get('project_name')
+                project_description = project_info.get('description')
+
+        memory = MemoryManager.load(project_dir, project_name, raw=True)
+
+        if project_description:
+            memory['核心記憶模塊']['專案總結'] = project_description
+        elif project_name:
+            memory['核心記憶模塊']['專案總結'] = f"專案 {project_name} 正在建構與優化中。"
+
+        meta = memory.setdefault('_meta', {})
+        history = meta.setdefault('history', [])
+        timestamp = datetime.now().strftime('%m/%d %H:%M')
+        prompt_preview = MemoryManager._truncate(user_prompt.replace('\n', ' '), 80)
+        outcome_text = '成功完成當前任務' if result.success else f"發生問題: {MemoryManager._truncate(result.error or '未知錯誤', 40)}"
+        history.append({
+            'timestamp': timestamp,
+            'prompt': prompt_preview,
+            'outcome': outcome_text
+        })
+        history[:] = history[-5:]
+
+        short_memory_lines = [
+            f"{item['timestamp']} - {item['prompt']} → {item['outcome']}"
+            for item in history[-3:]
+        ]
+        memory['核心記憶模塊']['短期記憶'] = ' / '.join(short_memory_lines) if short_memory_lines else '尚無近期互動記錄。'
+
+        long_term_notes = meta.setdefault('long_term_notes', [])
+        if result.success:
+            changed_files = len(result.files_created) + len(result.files_updated)
+            action_label = '迭代' if result.is_iteration else '初始交付'
+            note = f"{datetime.now().strftime('%m/%d')} 完成{action_label}，處理 {changed_files} 個檔案。"
+        else:
+            note = f"{datetime.now().strftime('%m/%d')} 需排查錯誤：{MemoryManager._truncate(result.error or '未知錯誤', 30)}"
+        long_term_notes.append(note)
+        long_term_notes[:] = long_term_notes[-6:]
+        memory['核心記憶模塊']['長期記憶'] = '；'.join(long_term_notes[-3:]) if long_term_notes else '尚未累積長期經驗。'
+
+        goals = memory['核心記憶模塊'].get('專案目標') or MemoryManager._default_goals()
+        # 確保結構完整
+        for goal in goals:
+            goal.setdefault('狀態', '未開始')
+            goal.setdefault('是否為當前任務', False)
+
+        if history:
+            MemoryManager._set_goal_status(goals, 1, '已完成')
+
+        if result.success:
+            MemoryManager._set_goal_status(goals, 2, '已完成')
+            MemoryManager._set_goal_status(goals, 3, '進行中')
+            MemoryManager._set_goal_status(goals, 4, '未開始')
+            MemoryManager._set_current_goal(goals, 3)
+        else:
+            MemoryManager._set_goal_status(goals, 2, '進行中')
+            MemoryManager._set_goal_status(goals, 3, '未開始')
+            MemoryManager._set_goal_status(goals, 4, '未開始')
+            MemoryManager._set_current_goal(goals, 2)
+
+        memory['核心記憶模塊']['專案目標'] = goals
+
+        previous_score = memory.get('評分', 75)
+        if result.success:
+            delta = 8 if (result.files_created or result.files_updated) else 5
+            score = min(100, previous_score + delta)
+            memory['內容評價'] = "本輪回覆順利完成任務並提供具體步驟，內容結構穩定。"
+            memory['扣分原因'] = "無"
+            if result.files_created or result.files_updated:
+                memory['改進建議'] = "建議後續針對更新內容進行測試，並同步補充文件。"
+            else:
+                memory['改進建議'] = "建議確認是否仍需新增程式碼或補充更多上下文資訊。"
+        else:
+            score = max(30, previous_score - 12)
+            memory['內容評價'] = "本輪回覆尚未完成需求，需優先處理錯誤訊息。"
+            memory['扣分原因'] = MemoryManager._truncate(result.error or '流程發生未知錯誤', 120)
+            memory['改進建議'] = "請依照錯誤提示調整程式或補充更多背景資訊，再次嘗試。"
+
+        memory['評分'] = score
+
+        MemoryManager.save(project_dir, memory)
+        return MemoryManager._sanitize(memory)
+
+# ============================================
 # 專案管理模塊
 # ============================================
 
@@ -592,7 +780,8 @@ class ProjectManager:
                     files_data.append({
                         'name': str(rel_path),
                         'type': 'text/plain',
-                        'content': content
+                        'content': content,
+                        'source': 'project'
                     })
                     logger.info(f"已載入檔案: {rel_path}")
                 except Exception as e:
@@ -1663,9 +1852,10 @@ class ProcessManager:
         attach_terminal: bool = False
     ) -> ProcessResult:
         """執行完整的自動化流程 - 修復版"""
-        
+
         result = ProcessResult(success=False, is_iteration=is_iteration)
-        
+        result.final_project_dir = folder_path
+
         try:
             if is_iteration:
                 logger.info("迭代模式:自動載入專案所有檔案")
@@ -1689,7 +1879,11 @@ class ProcessManager:
                 folder_path,
                 'user',
                 prompt,
-                files=[{'name': f.get('name'), 'type': f.get('type')} for f in (files or [])],
+                files=[{
+                    'name': f.get('name'),
+                    'type': f.get('type'),
+                    'source': f.get('source', 'user')
+                } for f in (files or [])],
                 terminal_output=terminal_output
             )
             
@@ -1856,6 +2050,7 @@ class ProcessManager:
                 final_project_dir = folder_path
             else:
                 final_project_dir = str(Path(folder_path) / project.project_name)
+            result.final_project_dir = final_project_dir
             
             # ⭐ 關鍵修復:處理對話遷移
             if not is_iteration and folder_path != final_project_dir:
@@ -2066,6 +2261,9 @@ class ProcessManager:
             logger.error(f"處理流程失敗: {e}")
             import traceback
             logger.error(traceback.format_exc())
+
+            if not result.final_project_dir:
+                result.final_project_dir = folder_path
             
             if not result.ai_response:
                 result.ai_response = "無法獲取 AI 回應"
@@ -2179,7 +2377,9 @@ def load_project():
                 'usage_metadata': msg.usage_metadata  # ⭐ 直接傳遞
             }
             messages_data.append(msg_dict)
-        
+
+        memory_snapshot = MemoryManager.load(project_dir, project_info.get('project_name'))
+
         return jsonify({
             'success': True,
             'project_info': project_info,
@@ -2190,7 +2390,8 @@ def load_project():
                 'messages': messages_data,
                 'created_at': conversation.created_at,
                 'updated_at': conversation.updated_at
-            }
+            },
+            'memory': memory_snapshot
         })
         
     except Exception as e:
@@ -2324,9 +2525,10 @@ def run_process():
             'screenshots': result.screenshots,
             'is_iteration': result.is_iteration,
             'usage_metadata': result.usage_metadata,
-            'terminal_output': result.terminal_output
+            'terminal_output': result.terminal_output,
+            'final_project_dir': result.final_project_dir or folder_path
         }
-        
+
         if result.project_data:
             response_data['project'] = {
                 'name': result.project_data.project_name,
@@ -2335,7 +2537,17 @@ def run_process():
                 'main_file': result.project_data.main_file,
                 'has_gui': any(f.opens_window for f in result.project_data.files)
             }
-        
+
+        final_dir = result.final_project_dir or folder_path
+        try:
+            response_data['memory'] = MemoryManager.update_after_interaction(
+                final_dir,
+                prompt,
+                result
+            )
+        except Exception as memory_error:
+            logger.error(f"更新記憶失敗: {memory_error}")
+
         return jsonify(response_data)
         
     except Exception as e:
@@ -2409,13 +2621,30 @@ def serve_screenshot(filename):
     filepath = SCREENSHOT_DIR / filename
     if filepath.exists():
         return send_file(
-            filepath, 
+            filepath,
             mimetype='image/png',
             as_attachment=False,
             download_name=filename
         )
     else:
         return "Screenshot not found", 404
+
+@app.route('/terminal-output', methods=['GET'])
+def get_terminal_output_snapshot():
+    """即時取得所有程式的 Terminal 輸出"""
+    try:
+        ProgramManager.update_outputs()
+        output = ProgramManager.get_all_terminal_output()
+        return jsonify({
+            'success': True,
+            'terminal_output': output
+        })
+    except Exception as e:
+        logger.error(f"獲取 Terminal 輸出失敗: {e}")
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
 
 @app.route('/running-programs', methods=['GET'])
 def get_running_programs():

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -13,6 +13,9 @@ let allProjects = [];
 let modelConfig = null;
 let sidebarCollapsed = false;
 let MODEL_LIMITS = {};
+let currentMemory = null;
+let autoAttachMemory = false;
+const AUTO_MEMORY_STORAGE_KEY = 'ai-controller-auto-memory';
 
 // ============================================
 // Loading Overlay 控制 - 修復版
@@ -48,7 +51,10 @@ window.addEventListener('DOMContentLoaded', () => {
     loadProjectsList();
     checkRunningPrograms();
     setInterval(checkRunningPrograms, 5000);
-    
+
+    autoAttachMemory = localStorage.getItem(AUTO_MEMORY_STORAGE_KEY) === 'true';
+    updateMemoryToggleUI();
+
     // 點擊外部關閉選單
     document.addEventListener('click', (e) => {
         const plusMenu = document.getElementById('plusMenu');
@@ -118,7 +124,8 @@ async function processFile(file) {
                 type: file.type || 'text/plain',
                 size: file.size,
                 content: e.target.result,
-                isText: isTextFile
+                isText: isTextFile,
+                source: 'user'
             });
             resolve();
         };
@@ -279,6 +286,24 @@ function toggleAttachTerminal() {
     togglePlusMenu();
 }
 
+function toggleAutoMemory() {
+    autoAttachMemory = !autoAttachMemory;
+    localStorage.setItem(AUTO_MEMORY_STORAGE_KEY, autoAttachMemory ? 'true' : 'false');
+    updateMemoryToggleUI();
+    showNotification(autoAttachMemory ? '已啟用自動附加記憶摘要' : '已關閉自動附加記憶摘要', autoAttachMemory ? 'success' : 'info');
+    togglePlusMenu();
+}
+
+function updateMemoryToggleUI() {
+    const menuItem = document.getElementById('memoryMenuItem');
+    if (!menuItem) return;
+    if (autoAttachMemory) {
+        menuItem.classList.add('active');
+    } else {
+        menuItem.classList.remove('active');
+    }
+}
+
 function showAdvancedSettings() {
     togglePlusMenu();
     showSettingsModal();
@@ -309,13 +334,177 @@ function handleKeyDown(event) {
     }
 }
 
+function formatMemoryAttachment(memory) {
+    if (!memory) return '';
+    const core = memory['核心記憶模塊'] || {};
+    const goals = Array.isArray(core['專案目標']) ? core['專案目標'] : [];
+    const goalLines = (goals.length ? goals : [{ '步驟': '-', '任務': '尚未設定目標', '狀態': '未開始' }]).map(goal => {
+        const status = goal['狀態'] || '未開始';
+        return `  - 第${goal['步驟']}步「${goal['任務']}」：${status}`;
+    });
+
+    return [
+        '【上一輪記憶摘要】',
+        `- 專案總結：${core['專案總結'] || '尚未建立摘要'}`,
+        `- 短期記憶：${core['短期記憶'] || '暫無紀錄'}`,
+        `- 長期記憶：${core['長期記憶'] || '暫無紀錄'}`,
+        '- 專案目標：',
+        ...goalLines,
+        `- 上輪改進建議：${memory['改進建議'] || '暫無建議'}`
+    ].join('\n');
+}
+
+async function fetchTerminalSnapshot() {
+    if (!attachTerminal) return '';
+    try {
+        const response = await fetch('/terminal-output');
+        const data = await response.json();
+        if (data.success) {
+            return data.terminal_output || '';
+        }
+    } catch (error) {
+        console.warn('取得 Terminal 輸出失敗', error);
+    }
+    return '';
+}
+
+function renderMemoryPanel(memory) {
+    const panel = document.getElementById('memoryPanel');
+    if (!panel) return;
+
+    if (!memory) {
+        currentMemory = null;
+        panel.style.display = 'none';
+        const toggleText = document.getElementById('memoryToggleText');
+        if (toggleText) {
+            toggleText.textContent = '收合';
+        }
+        return;
+    }
+
+    currentMemory = memory;
+    panel.style.display = 'flex';
+
+    const scoreValue = document.getElementById('memoryScoreValue');
+    if (scoreValue) {
+        const score = typeof memory['評分'] === 'number' ? memory['評分'] : null;
+        scoreValue.textContent = score !== null ? Math.round(score) : '--';
+        scoreValue.classList.remove('score-good', 'score-medium', 'score-low');
+        if (score !== null) {
+            if (score >= 80) {
+                scoreValue.classList.add('score-good');
+            } else if (score >= 60) {
+                scoreValue.classList.add('score-medium');
+            } else {
+                scoreValue.classList.add('score-low');
+            }
+        }
+    }
+
+    const contentReview = document.getElementById('memoryContentReview');
+    if (contentReview) {
+        contentReview.textContent = memory['內容評價'] || '尚無評語。';
+    }
+
+    const deduction = document.getElementById('memoryDeduction');
+    if (deduction) {
+        deduction.textContent = memory['扣分原因'] || '無';
+    }
+
+    const improvement = document.getElementById('memoryImprovement');
+    if (improvement) {
+        improvement.textContent = memory['改進建議'] || '暫無建議。';
+    }
+
+    const core = memory['核心記憶模塊'] || {};
+    const projectSummary = document.getElementById('memoryProjectSummary');
+    if (projectSummary) {
+        projectSummary.textContent = core['專案總結'] || '尚未建立摘要。';
+    }
+
+    const shortTerm = document.getElementById('memoryShortTerm');
+    if (shortTerm) {
+        shortTerm.textContent = core['短期記憶'] || '尚無近期互動記錄。';
+    }
+
+    const longTerm = document.getElementById('memoryLongTerm');
+    if (longTerm) {
+        longTerm.textContent = core['長期記憶'] || '尚未累積長期經驗。';
+    }
+
+    const goalsList = document.getElementById('memoryGoalsList');
+    if (goalsList) {
+        goalsList.innerHTML = '';
+        const goals = Array.isArray(core['專案目標']) ? core['專案目標'] : [];
+        goals.forEach(goal => {
+            const goalRow = document.createElement('div');
+            goalRow.className = 'memory-goal-row';
+            const status = goal['狀態'] || '未開始';
+            const isCurrent = goal['是否為當前任務'];
+
+            goalRow.classList.add(
+                status === '已完成' ? 'completed' : status === '進行中' ? 'active' : 'pending'
+            );
+            if (isCurrent) {
+                goalRow.classList.add('current');
+            }
+
+            const statusBadge = document.createElement('span');
+            statusBadge.className = 'goal-status';
+            statusBadge.textContent = status;
+
+            const goalText = document.createElement('span');
+            goalText.className = 'goal-text';
+            const step = goal['步驟'] || '';
+            goalText.textContent = `步驟 ${step}：${goal['任務'] || '未定義任務'}`;
+
+            goalRow.appendChild(statusBadge);
+            goalRow.appendChild(goalText);
+            goalsList.appendChild(goalRow);
+        });
+
+        if (goals.length === 0) {
+            const emptyRow = document.createElement('div');
+            emptyRow.className = 'memory-goal-row pending';
+            const statusBadge = document.createElement('span');
+            statusBadge.className = 'goal-status';
+            statusBadge.textContent = '未開始';
+            const goalText = document.createElement('span');
+            goalText.className = 'goal-text';
+            goalText.textContent = '尚未設定任務目標';
+            emptyRow.appendChild(statusBadge);
+            emptyRow.appendChild(goalText);
+            goalsList.appendChild(emptyRow);
+        }
+    }
+
+    const toggleText = document.getElementById('memoryToggleText');
+    if (toggleText) {
+        toggleText.textContent = panel.classList.contains('collapsed') ? '展開' : '收合';
+    }
+}
+
+function clearMemoryPanel() {
+    renderMemoryPanel(null);
+}
+
+function toggleMemoryPanel() {
+    const panel = document.getElementById('memoryPanel');
+    if (!panel) return;
+    const isCollapsed = panel.classList.toggle('collapsed');
+    const toggleText = document.getElementById('memoryToggleText');
+    if (toggleText) {
+        toggleText.textContent = isCollapsed ? '展開' : '收合';
+    }
+}
+
 // ============================================
 // 核心功能
 // ============================================
 async function handleSubmit() {
     const input = document.getElementById('mainInput');
     const prompt = input?.value.trim();
-    
+
     if (!prompt) return;
 
     if (!currentProjectDir) {
@@ -327,7 +516,25 @@ async function handleSubmit() {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
 
-    addMessage('user', prompt);
+    const terminalSnapshot = await fetchTerminalSnapshot();
+    const filesForMessage = uploadedFiles.map(file => ({
+        name: file.name,
+        type: file.type,
+        source: file.source || 'user'
+    }));
+
+    let preparedPrompt = prompt;
+    if (autoAttachMemory && currentMemory) {
+        const memoryText = formatMemoryAttachment(currentMemory);
+        if (memoryText) {
+            preparedPrompt = `${prompt}\n\n${memoryText}`;
+        }
+    }
+
+    addMessage('user', preparedPrompt, {
+        files: filesForMessage,
+        terminalOutput: terminalSnapshot
+    });
 
     input.value = '';
     updateSubmitButton();
@@ -343,7 +550,7 @@ async function handleSubmit() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 folder_path: currentProjectDir,
-                prompt: prompt,
+                prompt: preparedPrompt,
                 config: config,
                 files: uploadedFiles,
                 is_iteration: isIterationMode,
@@ -354,22 +561,29 @@ async function handleSubmit() {
 
         const result = await response.json();
 
+        if (result.memory) {
+            renderMemoryPanel(result.memory);
+        }
+
         if (result.success) {
-            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output);
-            
+            const finalDir = result.final_project_dir || currentProjectDir;
+            addMessage('assistant', result.output, {
+                usageMetadata: result.usage_metadata,
+                terminalOutput: result.terminal_output
+            });
+
             if (result.project) {
                 currentProject = result.project;
                 if (result.ai_response_json) {
                     currentProject.json_data = result.ai_response_json;
                     displayProjectStructure(result.ai_response_json.files);
                 }
-                
+
                 document.getElementById('currentProjectName').textContent = currentProject.name;
-                
+
                 if (!isIterationMode) {
-                    const newProjectDir = currentProjectDir + '/' + currentProject.name;
-                    currentProjectDir = newProjectDir;
-                    
+                    currentProjectDir = finalDir;
+
                     isIterationMode = true;
                     const badge = document.getElementById('projectModeBadge');
                     if (badge) {
@@ -379,14 +593,20 @@ async function handleSubmit() {
                 }
             }
 
+            if (finalDir) {
+                currentProjectDir = finalDir;
+            }
+
             showNotification(result.is_iteration ? '專案迭代成功!' : '專案創建成功!', 'success');
-            
+
             loadProjectsList();
             uploadedFiles = [];
             updateFilesPreview();
             updateAttachedFilesDisplay();
         } else {
-            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`);
+            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`, {
+                terminalOutput: result.terminal_output
+            });
             showNotification(`執行失敗：${result.error}`, 'error');
         }
     } catch (error) {
@@ -397,10 +617,13 @@ async function handleSubmit() {
     }
 }
 
-function addMessage(role, content, usageMetadata = null, terminalOutput = null) {
+function addMessage(role, content, options = {}) {
+    const usageMetadata = options?.usageMetadata || null;
+    const terminalOutput = options?.terminalOutput || null;
+    const files = Array.isArray(options?.files) ? options.files : [];
     const container = document.getElementById('resultsContainer');
     if (!container) return;
-    
+
     const message = document.createElement('div');
     message.className = `result-message ${role} selectable`;
 
@@ -424,7 +647,45 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
 
     message.appendChild(header);
     message.appendChild(messageContent);
-    
+
+    const attachmentFiles = files.filter(file => (file.source || 'user') !== 'project');
+    if (attachmentFiles.length > 0) {
+        const attachmentsSection = document.createElement('div');
+        attachmentsSection.className = 'message-attachments';
+
+        const attachmentsTitle = document.createElement('div');
+        attachmentsTitle.className = 'attachments-title';
+        attachmentsTitle.textContent = `附加檔案 (${attachmentFiles.length})`;
+        attachmentsSection.appendChild(attachmentsTitle);
+
+        const visibleFiles = attachmentFiles.slice(0, 5);
+        visibleFiles.forEach(file => {
+            const chip = document.createElement('div');
+            chip.className = 'attachment-chip';
+
+            const icon = document.createElement('span');
+            icon.className = 'attachment-icon';
+            icon.textContent = '📎';
+
+            const name = document.createElement('span');
+            name.className = 'attachment-name';
+            name.textContent = file.name || '未命名檔案';
+
+            chip.appendChild(icon);
+            chip.appendChild(name);
+            attachmentsSection.appendChild(chip);
+        });
+
+        if (attachmentFiles.length > visibleFiles.length) {
+            const more = document.createElement('div');
+            more.className = 'attachment-more';
+            more.textContent = `+${attachmentFiles.length - visibleFiles.length} 更多`;
+            attachmentsSection.appendChild(more);
+        }
+
+        message.appendChild(attachmentsSection);
+    }
+
     // ✅ Terminal輸出只顯示在用戶消息中
     if (role === 'user' && terminalOutput && terminalOutput.trim()) {
         const terminalSection = document.createElement('div');
@@ -513,7 +774,8 @@ async function createNewProject() {
             document.getElementById('emptyState').style.display = 'none';
             document.getElementById('resultsContainer').style.display = 'block';
             document.getElementById('resultsContainer').innerHTML = '';
-            
+            clearMemoryPanel();
+
             showNotification('已選擇專案資料夾', 'success');
             document.getElementById('mainInput')?.focus();
         } else {
@@ -673,13 +935,14 @@ async function selectProject(project) {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
     document.getElementById('resultsContainer').innerHTML = '';
-    
+
     uploadedFiles = [];
     updateFilesPreview();
     updateAttachedFilesDisplay();
-    
+    clearMemoryPanel();
+
     await loadExistingProject(project.path);
-    
+
     showNotification(`已切換到專案: ${project.name}`, 'success');
 }
 
@@ -715,15 +978,26 @@ async function loadExistingProject(projectDir) {
                 const container = document.getElementById('resultsContainer');
                 if (container) {
                     container.innerHTML = '';
-                    
+
                     for (const msg of result.conversation.messages) {
-                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output);
+                        addMessage(msg.role, msg.content, {
+                            usageMetadata: msg.usage_metadata,
+                            terminalOutput: msg.terminal_output,
+                            files: msg.files
+                        });
                     }
                 }
             }
-            
+
+            if (result.memory) {
+                renderMemoryPanel(result.memory);
+            } else {
+                clearMemoryPanel();
+            }
+
             return true;
         } else {
+            clearMemoryPanel();
             return false;
         }
     } catch (error) {
@@ -835,10 +1109,11 @@ function resetToHome() {
     document.querySelectorAll('.project-item').forEach(item => {
         item.classList.remove('active');
     });
-    
+
     updateFilesPreview();
     updateAttachedFilesDisplay();
-    
+    clearMemoryPanel();
+
     showNotification('已回到初始介面', 'info');
 }
 

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -375,6 +375,22 @@ body {
     padding: 24px;
 }
 
+.conversation-layout {
+    width: 100%;
+    max-width: 1200px;
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+}
+
+.conversation-column {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
 .empty-state {
     max-width: 900px;
     width: 100%;
@@ -814,10 +830,11 @@ body {
 /* 結果容器 */
 /* =================================== */
 .results-container {
-    max-width: 900px;
+    max-width: none;
     width: 100%;
-    margin: 0 auto;
+    margin: 0;
     padding: 20px;
+    box-sizing: border-box;
 }
 
 .result-message {
@@ -826,6 +843,251 @@ body {
     padding: 16px;
     margin-bottom: 16px;
     border: 1px solid var(--border-light);
+}
+
+.message-attachments {
+    margin-top: 12px;
+    padding: 12px;
+    border-radius: 10px;
+    background: var(--bg-tertiary);
+    border: 1px dashed var(--border-light);
+}
+
+.attachments-title {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+
+.attachment-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    font-size: 13px;
+    color: var(--text-primary);
+    margin: 0 8px 8px 0;
+}
+
+.attachment-icon {
+    font-size: 14px;
+}
+
+.attachment-name {
+    max-width: 160px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.attachment-more {
+    display: inline-block;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 4px;
+}
+
+/* =================================== */
+/* 記憶面板 */
+/* =================================== */
+.memory-panel {
+    width: 320px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-light);
+    border-radius: 16px;
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    box-shadow: var(--shadow-sm);
+    position: sticky;
+    top: 96px;
+    max-height: calc(100vh - 160px);
+    overflow-y: auto;
+    transition: width 0.2s ease, opacity 0.2s ease;
+}
+
+.memory-panel.collapsed {
+    width: 140px;
+}
+
+.memory-panel.collapsed .memory-panel-body {
+    display: none;
+}
+
+.memory-panel.collapsed .memory-panel-header {
+    justify-content: center;
+}
+
+.memory-panel.collapsed .memory-title,
+.memory-panel.collapsed .memory-subtitle {
+    display: none;
+}
+
+.memory-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.memory-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.memory-subtitle {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-toggle-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid var(--border-light);
+    border-radius: 999px;
+    padding: 6px 12px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.memory-toggle-btn:hover {
+    background: var(--bg-tertiary);
+}
+
+.memory-score-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 14px;
+    border-radius: 12px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+}
+
+.score-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+    letter-spacing: 0.6px;
+}
+
+.score-value {
+    font-size: 32px;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.score-value.score-medium {
+    color: #f59e0b;
+}
+
+.score-value.score-low {
+    color: #ef4444;
+}
+
+.memory-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.memory-section-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.memory-text {
+    font-size: 13px;
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+.memory-divider {
+    height: 1px;
+    background: var(--border-light);
+    margin: 4px 0;
+}
+
+.memory-goals-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.memory-goal-row {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border-light);
+    background: var(--bg-primary);
+    font-size: 13px;
+}
+
+.memory-goal-row.completed {
+    border-color: rgba(16, 163, 127, 0.3);
+    background: rgba(16, 163, 127, 0.08);
+}
+
+.memory-goal-row.active {
+    border-color: rgba(14, 165, 233, 0.3);
+    background: rgba(14, 165, 233, 0.08);
+}
+
+.memory-goal-row.current {
+    box-shadow: 0 0 0 2px rgba(14, 165, 233, 0.1);
+}
+
+.goal-status {
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-light);
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-goal-row.completed .goal-status {
+    background: rgba(16, 163, 127, 0.15);
+    color: #0f9d74;
+}
+
+.memory-goal-row.active .goal-status {
+    background: rgba(14, 165, 233, 0.15);
+    color: #0ea5e9;
+}
+
+.goal-text {
+    flex: 1;
+    min-width: 0;
+    color: var(--text-primary);
+}
+
+@media (max-width: 1100px) {
+    .conversation-layout {
+        flex-direction: column;
+    }
+
+    .memory-panel {
+        position: relative;
+        top: 0;
+        width: 100%;
+        max-height: none;
+    }
+
+    .memory-panel.collapsed {
+        width: 100%;
+    }
 }
 
 .result-message.user {

--- a/vscode_controller_project3-1/templates/index.html
+++ b/vscode_controller_project3-1/templates/index.html
@@ -156,30 +156,93 @@
                 </div>
             </div>
 
-            <div class="empty-state" id="emptyState">
-                <h1 class="empty-title">選擇或創建一個專案開始工作</h1>
+            <div class="conversation-layout">
+                <div class="conversation-column">
+                    <div class="empty-state" id="emptyState">
+                        <h1 class="empty-title">選擇或創建一個專案開始工作</h1>
 
-                <div class="suggestions-grid">
-                    <div class="suggestion-card" onclick="useSuggestion('創建一個待辦事項應用，使用 Flask 後端和現代化的前端界面')">
-                        <div class="suggestion-title">待辦事項應用</div>
-                        <div class="suggestion-desc">創建一個功能完整的待辦清單應用</div>
+                        <div class="suggestions-grid">
+                            <div class="suggestion-card" onclick="useSuggestion('創建一個待辦事項應用，使用 Flask 後端和現代化的前端界面')">
+                                <div class="suggestion-title">待辦事項應用</div>
+                                <div class="suggestion-desc">創建一個功能完整的待辦清單應用</div>
+                            </div>
+                            <div class="suggestion-card" onclick="useSuggestion('生成一個幾何藝術生成器，使用 Python 和 Tkinter')">
+                                <div class="suggestion-title">幾何藝術生成器</div>
+                                <div class="suggestion-desc">創建隨機幾何圖案的藝術程式</div>
+                            </div>
+                            <div class="suggestion-card" onclick="useSuggestion('開發一個簡單的聊天應用，支持多用戶即時通訊')">
+                                <div class="suggestion-title">即時聊天應用</div>
+                                <div class="suggestion-desc">使用 WebSocket 的聊天室</div>
+                            </div>
+                            <div class="suggestion-card" onclick="useSuggestion('創建一個資料視覺化儀表板，展示圖表和統計資料')">
+                                <div class="suggestion-title">資料儀表板</div>
+                                <div class="suggestion-desc">互動式資料分析和視覺化</div>
+                            </div>
+                        </div>
                     </div>
-                    <div class="suggestion-card" onclick="useSuggestion('生成一個幾何藝術生成器，使用 Python 和 Tkinter')">
-                        <div class="suggestion-title">幾何藝術生成器</div>
-                        <div class="suggestion-desc">創建隨機幾何圖案的藝術程式</div>
+
+                    <div class="results-container" id="resultsContainer" style="display: none;"></div>
+                </div>
+
+                <div class="memory-panel" id="memoryPanel" style="display: none;">
+                    <div class="memory-panel-header">
+                        <div>
+                            <h3 class="memory-title">記憶系統</h3>
+                            <span class="memory-subtitle">長短期記憶與評分改進</span>
+                        </div>
+                        <button class="memory-toggle-btn" onclick="toggleMemoryPanel()" type="button">
+                            <span id="memoryToggleText">收合</span>
+                            <svg class="icon-small" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="15 18 9 12 15 6"/>
+                            </svg>
+                        </button>
                     </div>
-                    <div class="suggestion-card" onclick="useSuggestion('開發一個簡單的聊天應用，支持多用戶即時通訊')">
-                        <div class="suggestion-title">即時聊天應用</div>
-                        <div class="suggestion-desc">使用 WebSocket 的聊天室</div>
-                    </div>
-                    <div class="suggestion-card" onclick="useSuggestion('創建一個資料視覺化儀表板，展示圖表和統計資料')">
-                        <div class="suggestion-title">資料儀表板</div>
-                        <div class="suggestion-desc">互動式資料分析和視覺化</div>
+
+                    <div class="memory-panel-body" id="memoryPanelBody">
+                        <div class="memory-score-card">
+                            <span class="score-label">評分</span>
+                            <span class="score-value" id="memoryScoreValue">--</span>
+                        </div>
+
+                        <div class="memory-section">
+                            <div class="memory-section-title">內容評價</div>
+                            <p class="memory-text" id="memoryContentReview">尚未產生任何 AI 回覆。</p>
+                        </div>
+                        <div class="memory-section">
+                            <div class="memory-section-title">扣分原因</div>
+                            <p class="memory-text" id="memoryDeduction">無</p>
+                        </div>
+                        <div class="memory-section">
+                            <div class="memory-section-title">改進建議</div>
+                            <p class="memory-text" id="memoryImprovement">請先提交需求以建立記憶。</p>
+                        </div>
+
+                        <div class="memory-divider"></div>
+
+                        <div class="memory-section">
+                            <div class="memory-section-title">專案總結</div>
+                            <p class="memory-text" id="memoryProjectSummary">尚未建立摘要。</p>
+                        </div>
+                        <div class="memory-section">
+                            <div class="memory-section-title">短期記憶</div>
+                            <p class="memory-text" id="memoryShortTerm">尚無近期互動記錄。</p>
+                        </div>
+                        <div class="memory-section">
+                            <div class="memory-section-title">長期記憶</div>
+                            <p class="memory-text" id="memoryLongTerm">尚未累積長期經驗。</p>
+                        </div>
+                        <div class="memory-section">
+                            <div class="memory-section-title">專案目標</div>
+                            <div class="memory-goals-list" id="memoryGoalsList">
+                                <div class="memory-goal-row pending">
+                                    <span class="goal-status">未開始</span>
+                                    <span class="goal-text">尚未設定目標</span>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
-
-            <div class="results-container" id="resultsContainer" style="display: none;"></div>
         </div>
 
         <div class="input-area">
@@ -216,6 +279,13 @@
                                     <line x1="12" y1="19" x2="20" y2="19"/>
                                 </svg>
                                 <span>附加 Terminal 輸出</span>
+                            </div>
+                            <div class="menu-item" id="memoryMenuItem" onclick="toggleAutoMemory()">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M4 4h16v16H4z"/>
+                                    <path d="M8 8h8M8 12h6M8 16h4"/>
+                                </svg>
+                                <span>附加上一輪記憶</span>
                             </div>
                             <div class="menu-divider"></div>
                             <div class="menu-item" onclick="showAdvancedSettings()">


### PR DESCRIPTION
## Summary
- 建立 MemoryManager 模組，為每個專案持久化評分、記憶與目標，並於流程與載入 API 回傳最新快照
- 新增 `/terminal-output` API 與相關前端邏輯，確保訊息立即顯示附加的 Terminal 輸出與自動記憶內容
- 更新前端介面：加入可收合的記憶面板、記憶附加開關、附件顯示樣式與記憶摘要傳送機制

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68e8eb58d1548329a3638afe9bf55ffc