### PR TITLE
Add memory scoring system and enhance chat interface

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -195,6 +195,150 @@ class ProjectConversation:
     created_at: str = ""
     updated_at: str = ""
 
+
+class MemoryManager:
+    """長短期記憶與評分管理模塊"""
+
+    ERROR_KEYWORDS = ["失敗", "錯誤", "無法", "exception", "traceback"]
+
+    @staticmethod
+    def _limit_text(text: str, max_length: int = 200) -> str:
+        if len(text) <= max_length:
+            return text
+        return text[: max_length - 1] + "…"
+
+    @staticmethod
+    def _recent_user_messages(conversation: ProjectConversation, limit: int = 3) -> List[str]:
+        recent = [msg.content.strip() for msg in conversation.messages if msg.role == 'user' and msg.content.strip()]
+        return recent[-limit:]
+
+    @staticmethod
+    def _has_positive_confirmation(message: Optional[ConversationMessage]) -> bool:
+        if not message:
+            return False
+        content = message.content
+        return any(keyword in content for keyword in ["成功", "完成", "已更新", "已生成"])
+
+    @staticmethod
+    def _build_goals(conversation: ProjectConversation, project_info: Optional[Dict]) -> List[Dict[str, Any]]:
+        user_messages = [m for m in conversation.messages if m.role == 'user']
+        assistant_messages = [m for m in conversation.messages if m.role == 'assistant']
+        last_assistant = assistant_messages[-1] if assistant_messages else None
+        has_terminal = any((m.terminal_output or '').strip() for m in conversation.messages)
+
+        goals = [
+            {"步驟": 1, "任務": "梳理並確認使用者需求與上下文", "狀態": "未開始", "是否為當前任務": False},
+            {"步驟": 2, "任務": "生成或更新專案程式碼與結構", "狀態": "未開始", "是否為當前任務": False},
+            {"步驟": 3, "任務": "執行測試並檢視終端/截圖結果", "狀態": "未開始", "是否為當前任務": False},
+            {"步驟": 4, "任務": "整理評分、記憶並規劃下一步優化", "狀態": "未開始", "是否為當前任務": False},
+        ]
+
+        if user_messages:
+            goals[0]["狀態"] = "已完成"
+        else:
+            goals[0]["狀態"] = "進行中"
+
+        if assistant_messages:
+            goals[1]["狀態"] = "已完成" if MemoryManager._has_positive_confirmation(last_assistant) else "進行中"
+        else:
+            goals[1]["狀態"] = "未開始"
+
+        if has_terminal:
+            goals[2]["狀態"] = "進行中"
+        else:
+            goals[2]["狀態"] = "未開始"
+
+        goals[3]["狀態"] = "進行中" if assistant_messages else "未開始"
+
+        current_goal_index = next((idx for idx, goal in enumerate(goals) if goal["狀態"] != "已完成"), len(goals) - 1)
+        goals[current_goal_index]["是否為當前任務"] = True
+        return goals
+
+    @staticmethod
+    def build_memory_bundle(conversation: ProjectConversation, project_info: Optional[Dict] = None) -> Dict[str, Any]:
+        messages = conversation.messages
+        assistant_messages = [m for m in messages if m.role == 'assistant']
+        last_assistant = assistant_messages[-1] if assistant_messages else None
+        user_messages = [m for m in messages if m.role == 'user']
+
+        score = 100
+        deductions: List[str] = []
+
+        if not messages:
+            score = 60
+            deductions.append("尚未開始實際對話流程")
+        else:
+            if not assistant_messages:
+                score -= 15
+                deductions.append("尚未獲得 AI 端回覆")
+            if last_assistant and any(keyword in last_assistant.content for keyword in MemoryManager.ERROR_KEYWORDS):
+                score -= 20
+                deductions.append("最近一次 AI 回覆包含錯誤提示，需檢查流程")
+            if len(user_messages) > 0 and len(user_messages[-1].content.strip()) < 10:
+                score -= 5
+                deductions.append("最近一次使用者需求過於簡短，可能導致理解不足")
+
+        score = max(0, min(100, score))
+
+        total_turns = len(messages)
+        evaluation_parts = []
+        evaluation_parts.append(f"累計 {total_turns} 則訊息")
+        if assistant_messages:
+            evaluation_parts.append("已取得 AI 端回應")
+        if any((m.terminal_output or '').strip() for m in messages):
+            evaluation_parts.append("包含終端輸出記錄")
+        if project_info and project_info.get('description'):
+            evaluation_parts.append("專案描述已建立")
+        evaluation_text = "、".join(evaluation_parts) + "，整體流程穩定。"
+        evaluation_text = MemoryManager._limit_text(evaluation_text, 200)
+
+        if deductions:
+            improvement = "；".join(["針對下次迭代建議："] + [f"• {reason}" for reason in deductions])
+        else:
+            improvement = "保持目前節奏，持續更新程式碼並同步測試結果。"
+        improvement = MemoryManager._limit_text(improvement.replace("；", "\n"), 200)
+
+        project_summary = ""
+        if project_info and project_info.get('description'):
+            project_summary = project_info['description']
+        elif assistant_messages:
+            project_summary = MemoryManager._limit_text(assistant_messages[0].content.strip(), 160)
+        else:
+            project_summary = "尚未產出專案概要，可在下一輪請求時補充需求描述。"
+
+        recent_requests = MemoryManager._recent_user_messages(conversation)
+        if recent_requests:
+            stm_lines = [f"{idx + 1}. {content}" for idx, content in enumerate(recent_requests)]
+            short_term_memory = "\n".join(stm_lines)
+        else:
+            short_term_memory = "最近尚無新的使用者輸入。"
+
+        if project_info:
+            main_file = project_info.get('main_file') or "尚未指定主程式"
+            long_term_memory = f"專案名稱：{project_info.get('project_name', Path(conversation.project_dir).name)}；核心檔案：{main_file}。"
+        else:
+            long_term_memory = f"專案目錄：{Path(conversation.project_dir).name}，尚未生成詳細資訊。"
+
+        goals = MemoryManager._build_goals(conversation, project_info)
+
+        deduction_text = "、".join(deductions) if deductions else "無"
+
+        bundle = {
+            "評分": score,
+            "內容評價": evaluation_text,
+            "扣分原因": deduction_text or "無",
+            "改進建議": improvement,
+            "核心記憶模塊": {
+                "專案總結": MemoryManager._limit_text(project_summary, 200),
+                "短期記憶": MemoryManager._limit_text(short_term_memory, 200),
+                "長期記憶": MemoryManager._limit_text(long_term_memory, 200),
+                "專案目標": goals,
+            },
+        }
+
+        return bundle
+
+
 @dataclass
 class ProcessResult:
     """處理結果數據模型"""
@@ -2180,6 +2324,8 @@ def load_project():
             }
             messages_data.append(msg_dict)
         
+        memory_bundle = MemoryManager.build_memory_bundle(conversation, project_info)
+
         return jsonify({
             'success': True,
             'project_info': project_info,
@@ -2190,7 +2336,8 @@ def load_project():
                 'messages': messages_data,
                 'created_at': conversation.created_at,
                 'updated_at': conversation.updated_at
-            }
+            },
+            'memory': memory_bundle
         })
         
     except Exception as e:
@@ -2223,6 +2370,9 @@ def get_conversation(project_dir):
             }
             messages_data.append(msg_dict)
         
+        project_info = ProjectManager.load_project_info(project_dir)
+        memory_bundle = MemoryManager.build_memory_bundle(conversation, project_info)
+
         return jsonify({
             'success': True,
             'conversation': {
@@ -2230,7 +2380,8 @@ def get_conversation(project_dir):
                 'messages': messages_data,
                 'created_at': conversation.created_at,
                 'updated_at': conversation.updated_at
-            }
+            },
+            'memory': memory_bundle
         })
     except Exception as e:
         logger.error(f"獲取對話歷史失敗: {e}")
@@ -2238,6 +2389,19 @@ def get_conversation(project_dir):
             'success': False,
             'error': str(e)
         }), 500
+
+
+@app.route('/api/memory/<path:project_dir>', methods=['GET'])
+def get_memory_bundle(project_dir):
+    """取得指定專案的長短期記憶與評分摘要"""
+    try:
+        conversation = ConversationManager.load_conversation(project_dir)
+        project_info = ProjectManager.load_project_info(project_dir)
+        memory_bundle = MemoryManager.build_memory_bundle(conversation, project_info)
+        return jsonify({'success': True, 'memory': memory_bundle})
+    except Exception as e:
+        logger.error(f"生成記憶摘要失敗: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 @app.route('/api/projects', methods=['GET'])
 def get_projects():

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -13,6 +13,9 @@ let allProjects = [];
 let modelConfig = null;
 let sidebarCollapsed = false;
 let MODEL_LIMITS = {};
+let latestMemoryBundle = null;
+let attachMemoryBundle = true;
+let memoryDrawerInitialized = false;
 
 // ============================================
 // Loading Overlay 控制 - 修復版
@@ -48,7 +51,9 @@ window.addEventListener('DOMContentLoaded', () => {
     loadProjectsList();
     checkRunningPrograms();
     setInterval(checkRunningPrograms, 5000);
-    
+    renderMemoryBundle(null);
+    updateMemoryMenuState();
+
     // 點擊外部關閉選單
     document.addEventListener('click', (e) => {
         const plusMenu = document.getElementById('plusMenu');
@@ -279,6 +284,228 @@ function toggleAttachTerminal() {
     togglePlusMenu();
 }
 
+function updateMemoryMenuState() {
+    const menuItem = document.getElementById('memoryMenuItem');
+    if (menuItem) {
+        if (attachMemoryBundle) {
+            menuItem.classList.add('active');
+        } else {
+            menuItem.classList.remove('active');
+        }
+    }
+}
+
+async function toggleMemoryAttachment() {
+    attachMemoryBundle = !attachMemoryBundle;
+    updateMemoryMenuState();
+    try {
+        if (attachMemoryBundle) {
+            await ensureMemoryBundle();
+            showNotification('已啟用自動附加記憶摘要', 'success');
+        } else {
+            showNotification('已關閉自動附加記憶摘要', 'info');
+        }
+    } catch (error) {
+        console.error('更新記憶附加狀態失敗:', error);
+        showNotification('更新記憶附加狀態時發生錯誤', 'error');
+    } finally {
+        togglePlusMenu();
+    }
+}
+
+function toggleMemoryDrawer() {
+    const drawer = document.getElementById('memoryDrawer');
+    if (!drawer) return;
+    const isCollapsed = drawer.classList.toggle('collapsed');
+    if (!isCollapsed) {
+        memoryDrawerInitialized = true;
+    }
+}
+
+function renderMemoryBundle(bundle, emptyMessage = '尚未載入記憶摘要，請選擇專案或發送請求。') {
+    const drawer = document.getElementById('memoryDrawer');
+    const content = document.getElementById('memoryContent');
+    if (!drawer || !content) return;
+
+    if (!bundle) {
+        content.innerHTML = `<div class="memory-empty">${emptyMessage}</div>`;
+        drawer.classList.add('collapsed');
+        memoryDrawerInitialized = false;
+        return;
+    }
+
+    const core = bundle['核心記憶模塊'] || {};
+    content.innerHTML = '';
+
+    const scoreWrap = document.createElement('div');
+    scoreWrap.className = 'memory-score';
+    const scoreValue = document.createElement('div');
+    scoreValue.className = 'memory-score-value';
+    scoreValue.textContent = bundle['評分'] ?? 0;
+    const scoreLabel = document.createElement('div');
+    scoreLabel.className = 'memory-score-label';
+    scoreLabel.textContent = '本輪綜合評分';
+    scoreWrap.appendChild(scoreValue);
+    scoreWrap.appendChild(scoreLabel);
+    content.appendChild(scoreWrap);
+
+    const createSection = (title, bodyText) => {
+        const section = document.createElement('div');
+        section.className = 'memory-section';
+        const titleEl = document.createElement('div');
+        titleEl.className = 'memory-section-title';
+        titleEl.textContent = title;
+        const bodyEl = document.createElement('div');
+        bodyEl.className = 'memory-section-body';
+        if (bodyText !== undefined && bodyText !== null && bodyText !== '') {
+            bodyEl.textContent = bodyText;
+        } else {
+            bodyEl.textContent = '尚無資料';
+        }
+        section.appendChild(titleEl);
+        section.appendChild(bodyEl);
+        return { section, bodyEl };
+    };
+
+    const sections = [
+        createSection('內容評價', bundle['內容評價']),
+        createSection('扣分原因', bundle['扣分原因']),
+        createSection('改進建議', bundle['改進建議']),
+        createSection('專案總結', core['專案總結']),
+        createSection('短期記憶', core['短期記憶']),
+        createSection('長期記憶', core['長期記憶'])
+    ];
+
+    sections.forEach(({ section }) => content.appendChild(section));
+
+    const goalsData = Array.isArray(core['專案目標']) ? core['專案目標'] : [];
+    const { section: goalsSection, bodyEl: goalsBody } = createSection('專案目標', '');
+    const goalsList = document.createElement('div');
+    goalsList.className = 'memory-goals';
+
+    goalsData.forEach((goal) => {
+        const goalItem = document.createElement('div');
+        goalItem.className = 'memory-goal-item';
+
+        const titleRow = document.createElement('div');
+        titleRow.className = 'goal-title';
+
+        const nameEl = document.createElement('span');
+        nameEl.textContent = `步驟 ${goal['步驟'] || ''}: ${goal['任務'] || ''}`;
+
+        const statusEl = document.createElement('span');
+        statusEl.className = 'goal-status';
+        const statusText = goal['狀態'] || '未開始';
+        if (goal['是否為當前任務']) {
+            statusEl.classList.add('active');
+            statusEl.textContent = `${statusText} · 當前`; 
+        } else {
+            statusEl.textContent = statusText;
+        }
+
+        titleRow.appendChild(nameEl);
+        titleRow.appendChild(statusEl);
+        goalItem.appendChild(titleRow);
+
+        const detailEl = document.createElement('div');
+        detailEl.className = 'goal-detail';
+        detailEl.textContent = goal['是否為當前任務'] ? '目前優先處理此任務。' : '保持追蹤此項進度。';
+        goalItem.appendChild(detailEl);
+
+        goalsList.appendChild(goalItem);
+    });
+
+    if (!goalsData.length) {
+        const emptyGoal = document.createElement('div');
+        emptyGoal.className = 'goal-detail';
+        emptyGoal.textContent = '尚未設定具體目標。';
+        goalsList.appendChild(emptyGoal);
+    }
+
+    goalsBody.innerHTML = '';
+    goalsBody.appendChild(goalsList);
+    content.appendChild(goalsSection);
+
+    if (!memoryDrawerInitialized) {
+        drawer.classList.remove('collapsed');
+        memoryDrawerInitialized = true;
+    }
+}
+
+async function refreshMemoryBundle(showError = false) {
+    if (!currentProjectDir) {
+        latestMemoryBundle = null;
+        memoryDrawerInitialized = false;
+        renderMemoryBundle(null);
+        return null;
+    }
+
+    try {
+        const response = await fetch(`/api/memory/${encodeURIComponent(currentProjectDir)}`);
+        const result = await response.json();
+        if (result.success) {
+            latestMemoryBundle = result.memory;
+            renderMemoryBundle(latestMemoryBundle);
+            return latestMemoryBundle;
+        }
+        if (showError) {
+            showNotification(result.error || '無法獲取記憶摘要', 'error');
+        }
+    } catch (error) {
+        console.error('載入記憶摘要失敗:', error);
+        if (showError) {
+            showNotification('載入記憶摘要時發生錯誤', 'error');
+        }
+    }
+    return null;
+}
+
+async function ensureMemoryBundle() {
+    if (!attachMemoryBundle || !currentProjectDir) {
+        return;
+    }
+    if (!latestMemoryBundle) {
+        await refreshMemoryBundle();
+    }
+}
+
+function buildPromptWithMemory(prompt) {
+    if (!attachMemoryBundle || !latestMemoryBundle) {
+        return prompt;
+    }
+
+    const memoryText = formatMemoryAttachment(latestMemoryBundle);
+    return `${prompt}\n\n[自動附加記憶摘要]\n${memoryText}`;
+}
+
+function formatMemoryAttachment(bundle) {
+    if (!bundle) return '';
+    const core = bundle['核心記憶模塊'] || {};
+    const goals = Array.isArray(core['專案目標']) ? core['專案目標'] : [];
+
+    const lines = [
+        `評分：${bundle['評分'] ?? '未評分'}`,
+        `內容評價：${bundle['內容評價'] || '尚無'}`,
+        `扣分原因：${bundle['扣分原因'] || '無'}`,
+        `改進建議：${bundle['改進建議'] || '持續維持現有節奏。'}`,
+        `短期記憶：${core['短期記憶'] || '暫無短期記憶。'}`,
+        `長期記憶：${core['長期記憶'] || '暫無長期記憶。'}`,
+        '專案目標：'
+    ];
+
+    goals.forEach((goal) => {
+        const status = goal['狀態'] || '未開始';
+        const currentFlag = goal['是否為當前任務'] ? '（當前任務）' : '';
+        lines.push(`- 步驟${goal['步驟'] || ''}: ${goal['任務'] || ''}【${status}${currentFlag}】`);
+    });
+
+    if (!goals.length) {
+        lines.push('- 尚未建立專案目標。');
+    }
+
+    return lines.join('\n');
+}
+
 function showAdvancedSettings() {
     togglePlusMenu();
     showSettingsModal();
@@ -315,7 +542,7 @@ function handleKeyDown(event) {
 async function handleSubmit() {
     const input = document.getElementById('mainInput');
     const prompt = input?.value.trim();
-    
+
     if (!prompt) return;
 
     if (!currentProjectDir) {
@@ -326,8 +553,13 @@ async function handleSubmit() {
 
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
+    document.getElementById('conversationWrapper').style.display = 'flex';
 
-    addMessage('user', prompt);
+    await ensureMemoryBundle();
+    const finalPrompt = buildPromptWithMemory(prompt);
+    const attachmentsMeta = uploadedFiles.map(file => ({ name: file.name, type: file.type }));
+
+    addMessage('user', finalPrompt, null, null, attachmentsMeta);
 
     input.value = '';
     updateSubmitButton();
@@ -343,7 +575,7 @@ async function handleSubmit() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 folder_path: currentProjectDir,
-                prompt: prompt,
+                prompt: finalPrompt,
                 config: config,
                 files: uploadedFiles,
                 is_iteration: isIterationMode,
@@ -355,8 +587,8 @@ async function handleSubmit() {
         const result = await response.json();
 
         if (result.success) {
-            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output);
-            
+            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output, null);
+
             if (result.project) {
                 currentProject = result.project;
                 if (result.ai_response_json) {
@@ -380,29 +612,36 @@ async function handleSubmit() {
             }
 
             showNotification(result.is_iteration ? '專案迭代成功!' : '專案創建成功!', 'success');
-            
+
             loadProjectsList();
             uploadedFiles = [];
             updateFilesPreview();
             updateAttachedFilesDisplay();
+            await refreshMemoryBundle();
         } else {
-            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`);
+            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`, null, null, null);
             showNotification(`執行失敗：${result.error}`, 'error');
+            await refreshMemoryBundle(true);
         }
     } catch (error) {
-        addMessage('assistant', `✕ 連接錯誤：${error}`);
+        addMessage('assistant', `✕ 連接錯誤：${error}`, null, null, null);
         showNotification(`連接錯誤：${error}`, 'error');
+        await refreshMemoryBundle(true);
     } finally {
         hideLoading();
     }
 }
 
-function addMessage(role, content, usageMetadata = null, terminalOutput = null) {
+function addMessage(role, content, usageMetadata = null, terminalOutput = null, files = null) {
     const container = document.getElementById('resultsContainer');
     if (!container) return;
-    
+
     const message = document.createElement('div');
-    message.className = `result-message ${role} selectable`;
+    message.className = 'result-message selectable';
+    message.classList.add(role);
+    if (role === 'user') {
+        message.classList.add('user');
+    }
 
     const header = document.createElement('div');
     header.className = 'message-header';
@@ -424,20 +663,62 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
 
     message.appendChild(header);
     message.appendChild(messageContent);
-    
-    // ✅ Terminal輸出只顯示在用戶消息中
-    if (role === 'user' && terminalOutput && terminalOutput.trim()) {
+
+    if (Array.isArray(files) && files.length > 0) {
+        const attachmentsLabel = document.createElement('div');
+        attachmentsLabel.className = 'attachment-label';
+        attachmentsLabel.textContent = '附件';
+        message.appendChild(attachmentsLabel);
+
+        const attachmentsWrapper = document.createElement('div');
+        attachmentsWrapper.className = 'message-attachments';
+
+        files.forEach((file) => {
+            const chip = document.createElement('div');
+            chip.className = 'attachment-chip';
+
+            const icon = document.createElement('span');
+            icon.className = 'attachment-icon';
+            icon.textContent = '📎';
+
+            const nameEl = document.createElement('span');
+            nameEl.textContent = file.name || file.filename || '未命名檔案';
+
+            chip.appendChild(icon);
+            chip.appendChild(nameEl);
+
+            if (file.type) {
+                const typeEl = document.createElement('span');
+                typeEl.style.color = 'var(--text-tertiary)';
+                typeEl.textContent = file.type.split('/').pop();
+                chip.appendChild(typeEl);
+            }
+
+            attachmentsWrapper.appendChild(chip);
+        });
+
+        message.appendChild(attachmentsWrapper);
+    }
+
+    if (terminalOutput && terminalOutput.trim()) {
         const terminalSection = document.createElement('div');
         terminalSection.className = 'terminal-output-section';
-        terminalSection.innerHTML = `
-            <div class="terminal-header">
-                <span class="terminal-title">Terminal 輸出</span>
-            </div>
-            <div class="terminal-body selectable">${terminalOutput}</div>
-        `;
+        const terminalHeader = document.createElement('div');
+        terminalHeader.className = 'terminal-header';
+        const terminalTitle = document.createElement('span');
+        terminalTitle.className = 'terminal-title';
+        terminalTitle.textContent = 'Terminal 輸出';
+        terminalHeader.appendChild(terminalTitle);
+
+        const terminalBody = document.createElement('div');
+        terminalBody.className = 'terminal-body selectable';
+        terminalBody.textContent = terminalOutput;
+
+        terminalSection.appendChild(terminalHeader);
+        terminalSection.appendChild(terminalBody);
         message.appendChild(terminalSection);
     }
-    
+
     // Token使用統計只顯示在AI回應中
     if (role === 'assistant' && usageMetadata && typeof usageMetadata === 'object') {
         const tokenUsage = document.createElement('div');
@@ -512,8 +793,13 @@ async function createNewProject() {
             document.getElementById('projectStructureSection').style.display = 'none';
             document.getElementById('emptyState').style.display = 'none';
             document.getElementById('resultsContainer').style.display = 'block';
+            document.getElementById('conversationWrapper').style.display = 'flex';
             document.getElementById('resultsContainer').innerHTML = '';
-            
+            latestMemoryBundle = null;
+            memoryDrawerInitialized = false;
+            renderMemoryBundle(null, '新專案尚未建立記憶摘要，請先提交需求。');
+            updateMemoryMenuState();
+
             showNotification('已選擇專案資料夾', 'success');
             document.getElementById('mainInput')?.focus();
         } else {
@@ -535,13 +821,15 @@ async function selectExistingFolder() {
         if (result.success && result.path) {
             currentProjectDir = result.path;
             isIterationMode = true;
-            
+
             uploadedFiles = [];
             updateFilesPreview();
             updateAttachedFilesDisplay();
-            
+
+            renderMemoryBundle(null, '正在載入記憶摘要...');
+
             const loadResult = await loadExistingProject(result.path);
-            
+
             if (loadResult) {
                 document.getElementById('currentProjectDisplay').style.display = 'block';
                 document.getElementById('currentProjectName').textContent = currentProject.name;
@@ -556,10 +844,11 @@ async function selectExistingFolder() {
                 document.querySelectorAll('.project-item').forEach(item => {
                     item.classList.remove('active');
                 });
-                
+
                 document.getElementById('emptyState').style.display = 'none';
                 document.getElementById('resultsContainer').style.display = 'block';
-                
+                document.getElementById('conversationWrapper').style.display = 'flex';
+
                 showNotification(`已載入專案: ${currentProject.name}`, 'success');
             } else {
                 showNotification('此資料夾不是有效的專案，將作為新專案', 'warning');
@@ -571,11 +860,17 @@ async function selectExistingFolder() {
                     badge.textContent = '新建';
                     badge.style.background = '#10a37f';
                 }
-                
+
                 document.getElementById('homeBtn').style.display = 'flex';
                 document.getElementById('projectStructureSection').style.display = 'none';
+                latestMemoryBundle = null;
+                memoryDrawerInitialized = false;
+                renderMemoryBundle(null, '新專案尚未建立記憶摘要，請先提交需求。');
+                updateMemoryMenuState();
+                document.getElementById('conversationWrapper').style.display = 'flex';
+                document.getElementById('resultsContainer').style.display = 'block';
             }
-            
+
             document.getElementById('mainInput')?.focus();
         } else {
             showNotification(result.error || '未選擇資料夾', 'warning');
@@ -673,13 +968,16 @@ async function selectProject(project) {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
     document.getElementById('resultsContainer').innerHTML = '';
-    
+
     uploadedFiles = [];
     updateFilesPreview();
     updateAttachedFilesDisplay();
-    
+
+    memoryDrawerInitialized = false;
+    renderMemoryBundle(null, '正在載入記憶摘要...');
+
     await loadExistingProject(project.path);
-    
+
     showNotification(`已切換到專案: ${project.name}`, 'success');
 }
 
@@ -693,7 +991,7 @@ async function loadExistingProject(projectDir) {
         });
         
         const result = await response.json();
-        
+
         if (result.success) {
             currentProject = {
                 name: result.project_info.project_name,
@@ -710,18 +1008,30 @@ async function loadExistingProject(projectDir) {
             
             document.getElementById('currentProjectName').textContent = currentProject.name;
             displayProjectStructure(result.project_info.files);
-            
+
             if (result.conversation && result.conversation.messages) {
                 const container = document.getElementById('resultsContainer');
                 if (container) {
                     container.innerHTML = '';
-                    
+
                     for (const msg of result.conversation.messages) {
-                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output);
+                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output, msg.files);
                     }
                 }
+                document.getElementById('resultsContainer').style.display = 'block';
+                document.getElementById('emptyState').style.display = 'none';
+                document.getElementById('conversationWrapper').style.display = 'flex';
             }
-            
+
+            if (result.memory) {
+                latestMemoryBundle = result.memory;
+                renderMemoryBundle(result.memory);
+            } else {
+                latestMemoryBundle = null;
+                memoryDrawerInitialized = false;
+                renderMemoryBundle(null, '專案尚未產生記憶摘要，請先進行一次對話。');
+            }
+
             return true;
         } else {
             return false;
@@ -831,14 +1141,19 @@ function resetToHome() {
     document.getElementById('resultsContainer').innerHTML = '';
     document.getElementById('projectStructureSection').style.display = 'none';
     document.getElementById('homeBtn').style.display = 'none';
+    document.getElementById('conversationWrapper').style.display = 'none';
     
     document.querySelectorAll('.project-item').forEach(item => {
         item.classList.remove('active');
     });
-    
+
     updateFilesPreview();
     updateAttachedFilesDisplay();
-    
+    latestMemoryBundle = null;
+    memoryDrawerInitialized = false;
+    renderMemoryBundle(null);
+    updateMemoryMenuState();
+
     showNotification('已回到初始介面', 'info');
 }
 

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -371,7 +371,7 @@ body {
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     padding: 24px;
 }
 
@@ -813,10 +813,20 @@ body {
 /* =================================== */
 /* 結果容器 */
 /* =================================== */
-.results-container {
-    max-width: 900px;
+.conversation-wrapper {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
     width: 100%;
+    max-width: 1200px;
     margin: 0 auto;
+}
+
+.results-container {
+    flex: 1;
+    max-width: 100%;
+    width: 100%;
+    margin: 0;
     padding: 20px;
 }
 
@@ -891,6 +901,39 @@ body {
     color: var(--text-primary);
 }
 
+.message-attachments {
+    margin-top: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.attachment-label {
+    margin-top: 12px;
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.attachment-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.attachment-icon {
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
 /* =================================== */
 /* Terminal 輸出區塊 */
 /* =================================== */
@@ -925,6 +968,149 @@ body {
     line-height: 1.4;
     white-space: pre-wrap;
     word-wrap: break-word;
+}
+
+/* =================================== */
+/* 記憶抽屜 */
+/* =================================== */
+.memory-drawer {
+    width: 320px;
+    min-width: 280px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-light);
+    border-radius: 16px;
+    box-shadow: var(--shadow-md);
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 160px);
+    position: sticky;
+    top: 24px;
+    transition: width 0.25s ease;
+}
+
+.memory-drawer.collapsed {
+    width: 52px;
+    min-width: 52px;
+    overflow: hidden;
+}
+
+.memory-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 14px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--text-primary);
+    font-weight: 500;
+    border-bottom: 1px solid var(--border-light);
+}
+
+.memory-drawer.collapsed .memory-toggle span {
+    display: none;
+}
+
+.memory-drawer.collapsed .memory-content {
+    display: none;
+}
+
+.memory-content {
+    padding: 14px 16px;
+    overflow-y: auto;
+}
+
+.memory-empty {
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.memory-score {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.memory-score-value {
+    font-size: 32px;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.memory-score-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-section {
+    margin-bottom: 16px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--border-light);
+}
+
+.memory-section:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.memory-section-title {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--text-primary);
+}
+
+.memory-section-body {
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+}
+
+.memory-goals {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.memory-goal-item {
+    padding: 8px 10px;
+    border-radius: 10px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    font-size: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.goal-title {
+    font-weight: 600;
+    color: var(--text-primary);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.goal-status {
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+}
+
+.goal-status.active {
+    background: rgba(16, 163, 127, 0.1);
+    color: var(--primary-color);
+}
+
+.goal-detail {
+    font-size: 11px;
+    color: var(--text-secondary);
 }
 
 /* =================================== */

--- a/vscode_controller_project3-1/templates/index.html
+++ b/vscode_controller_project3-1/templates/index.html
@@ -179,7 +179,21 @@
                 </div>
             </div>
 
-            <div class="results-container" id="resultsContainer" style="display: none;"></div>
+            <div class="conversation-wrapper" id="conversationWrapper" style="display: none;">
+                <div class="results-container" id="resultsContainer" style="display: none;"></div>
+                <div class="memory-drawer collapsed" id="memoryDrawer">
+                    <button class="memory-toggle" onclick="toggleMemoryDrawer()">
+                        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 12h16" />
+                            <path d="M10 6l-6 6 6 6" />
+                        </svg>
+                        <span>長短期記憶 / 評分面板</span>
+                    </button>
+                    <div class="memory-content" id="memoryContent">
+                        <div class="memory-empty">尚未載入記憶摘要，請選擇專案或發送請求。</div>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="input-area">
@@ -216,6 +230,12 @@
                                     <line x1="12" y1="19" x2="20" y2="19"/>
                                 </svg>
                                 <span>附加 Terminal 輸出</span>
+                            </div>
+                            <div class="menu-item" id="memoryMenuItem" onclick="toggleMemoryAttachment()">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 20c4.418 0 8-3.134 8-7s-3.582-7-8-7-8 3.134-8 7c0 2.485 1.51 4.673 3.781 5.943L8 21l3.087-2.058A8.705 8.705 0 0012 20z" />
+                                </svg>
+                                <span>自動附加記憶摘要</span>
                             </div>
                             <div class="menu-divider"></div>
                             <div class="menu-item" onclick="showAdvancedSettings()">


### PR DESCRIPTION
## Summary
- introduce a MemoryManager backend module that generates scoring, short/long-term memory, and project goals for each conversation
- expose memory bundles through project-loading endpoints and a new /api/memory route for on-demand refreshes
- redesign the frontend to display a collapsible memory drawer, attach memory context to prompts, show terminal output immediately, and render attached files per message
- update styles to accommodate the dual-column conversation layout and memory components

## Testing
- python -m compileall app.py static/app.js templates/index.html

------
https://chatgpt.com/codex/tasks/task_e_68e8eb58d1548329a3638afe9bf55ffc