### PR TITLE
feat: 建立記憶評分面板與即時附件呈現

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -211,6 +211,7 @@ class ProcessResult:
     is_iteration: bool = False
     usage_metadata: Optional[Dict] = None
     terminal_output: str = ""
+    memory_snapshot: Optional[Dict] = None
 
 # ============================================
 # JSON Schema 定義 - 繁體中文化
@@ -548,6 +549,208 @@ class ConversationManager:
         except Exception as e:
             logger.error(f"刪除對話檔案失敗: {e}")
             return False
+
+# ============================================
+# 記憶與自評管理模塊
+# ============================================
+
+class MemoryManager:
+    """專案記憶與自評管理器"""
+
+    @staticmethod
+    def get_memory_file(project_dir: str) -> Path:
+        import hashlib
+        project_hash = hashlib.md5(project_dir.encode()).hexdigest()
+        return CONVERSATIONS_DIR / f"memory_{project_hash}.json"
+
+    @classmethod
+    def create_default(cls, project_dir: str, project_name: str) -> Dict:
+        now = datetime.now().isoformat()
+        goals = [
+            {"步驟": 1, "任務": "理解並整理使用者需求", "狀態": "未開始", "是否為當前任務": True},
+            {"步驟": 2, "任務": "生成或更新核心程式碼", "狀態": "未開始", "是否為當前任務": False},
+            {"步驟": 3, "任務": "進行測試與驗證", "狀態": "未開始", "是否為當前任務": False},
+            {"步驟": 4, "任務": "整理文件與後續建議", "狀態": "未開始", "是否為當前任務": False},
+        ]
+
+        return {
+            "project_dir": project_dir,
+            "project_name": project_name,
+            "評分": 75,
+            "內容評價": "尚未產生評價，請與 AI 進行第一次協作後再查看。",
+            "扣分原因": "無",
+            "改進建議": "開始描述您的需求以建立專案記憶。",
+            "核心記憶模塊": {
+                "專案總結": f"專案「{project_name}」尚未建立摘要。",
+                "短期記憶": "尚無對話內容。",
+                "長期記憶": "",
+                "長期記憶紀錄": [],
+                "專案目標": goals,
+            },
+            "更新時間": now,
+        }
+
+    @staticmethod
+    def _shorten(text: Optional[str], limit: int = 120) -> str:
+        if not text:
+            return ""
+        cleaned = str(text).replace("\n", " ").replace("\r", " ").strip()
+        if len(cleaned) <= limit:
+            return cleaned
+        return cleaned[: limit - 1] + "…"
+
+    @classmethod
+    def load_memory(cls, project_dir: str, project_name: Optional[str] = None) -> Dict:
+        memory_file = cls.get_memory_file(project_dir)
+        if memory_file.exists():
+            try:
+                with open(memory_file, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if project_name and data.get("project_name") != project_name:
+                    data["project_name"] = project_name
+                core = data.setdefault("核心記憶模塊", {})
+                core.setdefault("專案目標", cls.create_default(project_dir, project_name or data.get("project_name", "專案"))["核心記憶模塊"]["專案目標"])
+                if "長期記憶紀錄" not in core:
+                    long_term = core.get("長期記憶")
+                    if isinstance(long_term, list):
+                        core["長期記憶紀錄"] = long_term
+                    elif isinstance(long_term, str) and long_term:
+                        core["長期記憶紀錄"] = [item.strip() for item in long_term.split("\n") if item.strip()]
+                    else:
+                        core["長期記憶紀錄"] = []
+                return data
+            except Exception as e:
+                logger.error(f"讀取記憶檔案失敗: {e}")
+
+        project_name = project_name or Path(project_dir).name
+        default_data = cls.create_default(project_dir, project_name)
+        cls.save_memory(project_dir, default_data)
+        return default_data
+
+    @classmethod
+    def save_memory(cls, project_dir: str, data: Dict) -> None:
+        memory_file = cls.get_memory_file(project_dir)
+        try:
+            with open(memory_file, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            logger.error(f"儲存記憶檔案失敗: {e}")
+
+    @classmethod
+    def update_memory(
+        cls,
+        project_dir: str,
+        project_name: str,
+        raw_prompt: str,
+        result: ProcessResult,
+        memory_context: Optional[Dict] = None,
+    ) -> Dict:
+        data = cls.load_memory(project_dir, project_name)
+
+        success = result.success
+        score = 90 if success else 60
+        if result.error:
+            score -= 10
+        if result.installation_logs:
+            score -= 5
+        score = max(0, min(100, score))
+
+        evaluation = (
+            "本輪回應成功提供具體步驟與細節，內容清晰且貼合需求。"
+            if success
+            else "本輪回應未能完成任務，需根據錯誤訊息重新調整程式。"
+        )
+
+        deduction = "無"
+        if result.error:
+            deduction = cls._shorten(result.error, 160) or "流程出現未知錯誤"
+
+        improvement = (
+            "請檢視已生成的程式碼，並規劃下一輪測試與驗證事項。"
+            if success
+            else f"請針對錯誤進行除錯：{cls._shorten(result.error, 160)}"
+        )
+
+        previous_core = data.get("核心記憶模塊", {})
+        previous_long_term = previous_core.get("長期記憶紀錄", [])
+        if not isinstance(previous_long_term, list):
+            previous_long_term = []
+
+        timestamp = datetime.now()
+        timestamp_text = timestamp.strftime("%Y-%m-%d %H:%M")
+
+        if success:
+            change_count = len(result.files_created or []) + len(result.files_updated or [])
+            action = "迭代" if result.is_iteration else "生成"
+            long_term_entry = f"{timestamp_text} 完成專案{action}，本輪處理 {change_count} 個檔案並提供執行說明。"
+        else:
+            long_term_entry = f"{timestamp_text} 遭遇錯誤，需要處理：{cls._shorten(result.error, 120)}"
+
+        if long_term_entry not in previous_long_term:
+            previous_long_term.append(long_term_entry)
+
+        previous_long_term = previous_long_term[-8:]
+        long_term_text = "\n".join(f"{idx + 1}. {entry}" for idx, entry in enumerate(previous_long_term))
+
+        short_term = f"使用者：{cls._shorten(raw_prompt, 140)}\nAI：{cls._shorten(result.output, 180)}"
+
+        summary = previous_core.get("專案總結") or ""
+        if result.project_data and result.project_data.description:
+            summary = result.project_data.description
+        elif not summary:
+            summary = f"專案「{project_name}」正在建立中，尚待整理完整摘要。"
+
+        default_goals = cls.create_default(project_dir, project_name)["核心記憶模塊"]["專案目標"]
+        goals = previous_core.get("專案目標", default_goals)
+        if not isinstance(goals, list) or len(goals) < 4:
+            goals = default_goals
+
+        goal_map = {goal.get("步驟"): goal for goal in goals}
+        for goal in goals:
+            goal["是否為當前任務"] = False
+
+        step1 = goal_map.get(1) or goals[0]
+        step1["狀態"] = "已完成"
+
+        step2 = goal_map.get(2) or goals[1]
+        step3 = goal_map.get(3) or goals[2]
+        step4 = goal_map.get(4) or goals[3]
+
+        if success:
+            step2["狀態"] = "已完成"
+            step3["狀態"] = "進行中"
+            step3["是否為當前任務"] = True
+            step4["狀態"] = step4.get("狀態", "未開始")
+        else:
+            step2["狀態"] = "進行中"
+            step2["是否為當前任務"] = True
+            step3["狀態"] = "未開始"
+            step4["狀態"] = "未開始"
+
+        updated_core = {
+            "專案總結": summary,
+            "短期記憶": short_term,
+            "長期記憶": long_term_text,
+            "長期記憶紀錄": previous_long_term,
+            "專案目標": goals,
+        }
+
+        memory_data = {
+            "project_dir": project_dir,
+            "project_name": project_name,
+            "評分": score,
+            "內容評價": evaluation,
+            "扣分原因": deduction,
+            "改進建議": improvement,
+            "核心記憶模塊": updated_core,
+            "更新時間": timestamp.isoformat(),
+        }
+
+        if memory_context:
+            memory_data["上一輪上下文"] = memory_context
+
+        cls.save_memory(project_dir, memory_data)
+        return memory_data
 
 # ============================================
 # 專案管理模塊
@@ -1655,12 +1858,14 @@ class ProcessManager:
     @staticmethod
     def run_automation_process(
         folder_path: str,
-        prompt: str,
+        raw_prompt: str,
+        full_prompt: str,
         config: AIConfig,
         files: List[Dict] = None,
         is_iteration: bool = False,
         attach_screenshot: bool = False,
-        attach_terminal: bool = False
+        attach_terminal: bool = False,
+        memory_context: Optional[Dict] = None,
     ) -> ProcessResult:
         """執行完整的自動化流程 - 修復版"""
         
@@ -1688,9 +1893,12 @@ class ProcessManager:
             ConversationManager.add_message(
                 folder_path,
                 'user',
-                prompt,
+                raw_prompt,
                 files=[{'name': f.get('name'), 'type': f.get('type')} for f in (files or [])],
-                terminal_output=terminal_output
+                metadata={
+                    '記憶附加': memory_context,
+                    '最終提示': full_prompt if full_prompt != raw_prompt else None
+                }
             )
             
             if is_iteration and attach_screenshot:
@@ -1760,7 +1968,7 @@ class ProcessManager:
                 logger.info("包含 Terminal 輸出")
             
             ai_response, json_data, usage_metadata = GeminiAI.generate_content(
-                prompt, config, files, terminal_output
+                full_prompt, config, files, terminal_output
             )
             result.ai_response = ai_response
             result.ai_response_json = json_data
@@ -1826,7 +2034,18 @@ class ProcessManager:
                     result.output,
                     metadata={'error': True, 'error_type': 'parse_error'}
                 )
-                
+
+                try:
+                    result.memory_snapshot = MemoryManager.update_memory(
+                        folder_path,
+                        Path(folder_path).name,
+                        raw_prompt,
+                        result,
+                        memory_context
+                    )
+                except Exception as mem_error:
+                    logger.error(f"更新記憶資料失敗: {mem_error}")
+
                 return result
             
             if is_iteration:
@@ -2060,7 +2279,18 @@ class ProcessManager:
                 terminal_output=result.terminal_output,
                 usage_metadata=usage_metadata  # ⭐ 直接傳遞 usage_metadata
             )
-            
+
+            try:
+                result.memory_snapshot = MemoryManager.update_memory(
+                    final_project_dir,
+                    project.project_name,
+                    raw_prompt,
+                    result,
+                    memory_context
+                )
+            except Exception as mem_error:
+                logger.error(f"更新記憶資料失敗: {mem_error}")
+
         except Exception as e:
             result.error = str(e)
             logger.error(f"處理流程失敗: {e}")
@@ -2077,7 +2307,18 @@ class ProcessManager:
                 f"執行失敗: {result.error}",
                 metadata={'error': True, 'error_type': 'execution_error'}
             )
-        
+
+            try:
+                result.memory_snapshot = MemoryManager.update_memory(
+                    folder_path,
+                    Path(folder_path).name,
+                    raw_prompt,
+                    result,
+                    memory_context
+                )
+            except Exception as mem_error:
+                logger.error(f"更新記憶資料失敗: {mem_error}")
+
         return result
 
 # ============================================
@@ -2186,6 +2427,7 @@ def load_project():
             'project_files': project_files,
             'project_structure': project_structure,
             'files_count': len(project_files),
+            'memory_snapshot': MemoryManager.load_memory(project_dir, project_info.get('project_name')),
             'conversation': {
                 'messages': messages_data,
                 'created_at': conversation.created_at,
@@ -2287,29 +2529,33 @@ def run_process():
         
         folder_path = data.get('folder_path')
         prompt = data.get('prompt')
+        raw_prompt = data.get('raw_prompt', prompt)
+        memory_context = data.get('memory_context')
         config_data = data.get('config', {})
         files = data.get('files', [])
         is_iteration = data.get('is_iteration', False)
         attach_screenshot = data.get('attach_screenshot', False)
         attach_terminal = data.get('attach_terminal', False)
-        
+
         if not all([folder_path, prompt]):
             return jsonify({
                 'success': False,
                 'error': '缺少必要參數(資料夾路徑或 AI 指令)',
                 'ai_response': ''
             }), 400
-        
+
         config = AIConfig(**{k: v for k, v in config_data.items() if k != 'response_mode'})
-        
+
         result = ProcessManager.run_automation_process(
             folder_path,
+            raw_prompt,
             prompt,
             config,
             files,
             is_iteration,
             attach_screenshot,
-            attach_terminal
+            attach_terminal,
+            memory_context
         )
         
         response_data = {
@@ -2324,7 +2570,8 @@ def run_process():
             'screenshots': result.screenshots,
             'is_iteration': result.is_iteration,
             'usage_metadata': result.usage_metadata,
-            'terminal_output': result.terminal_output
+            'terminal_output': result.terminal_output,
+            'memory_snapshot': result.memory_snapshot
         }
         
         if result.project_data:

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -13,6 +13,9 @@ let allProjects = [];
 let modelConfig = null;
 let sidebarCollapsed = false;
 let MODEL_LIMITS = {};
+let currentMemorySnapshot = null;
+let attachMemoryContext = true;
+let lastImprovementSuggestion = '';
 
 // ============================================
 // Loading Overlay 控制 - 修復版
@@ -37,6 +40,421 @@ function hideLoading() {
     if (overlay) {
         overlay.classList.remove('active');
     }
+}
+
+// ============================================
+// 工具函式
+// ============================================
+
+function escapeHtml(text) {
+    if (text === null || text === undefined) {
+        return '';
+    }
+    return String(text).replace(/[&<>"']/g, (char) => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+    })[char]);
+}
+
+function formatMessageContent(text) {
+    return escapeHtml(text || '').replace(/\n/g, '<br>');
+}
+
+function createAttachmentSection(files) {
+    if (!files || !files.length) {
+        return null;
+    }
+
+    const section = document.createElement('div');
+    section.className = 'attachments-section';
+
+    const header = document.createElement('div');
+    header.className = 'attachments-header';
+    header.innerHTML = `<span>附加檔案</span><span>${files.length}</span>`;
+    section.appendChild(header);
+
+    const list = document.createElement('div');
+    list.className = 'attachments-list';
+
+    files.forEach((file) => {
+        if (!file) return;
+        const item = document.createElement('div');
+        item.className = 'attachment-item';
+
+        const icon = document.createElement('div');
+        icon.className = 'attachment-icon';
+
+        const name = file.name || '未命名檔案';
+        let ext = '';
+        if (name.includes('.')) {
+            ext = name.split('.').pop() || '';
+        } else if (file.type) {
+            ext = file.type.split('/').pop() || '';
+        }
+        if (!ext) {
+            ext = 'FILE';
+        }
+        icon.textContent = ext.substring(0, 4).toUpperCase();
+
+        const text = document.createElement('span');
+        text.textContent = name;
+
+        item.appendChild(icon);
+        item.appendChild(text);
+        list.appendChild(item);
+    });
+
+    section.appendChild(list);
+    return section;
+}
+
+function appendMemoryContextItem(container, label, value) {
+    if (!container || value === undefined || value === null || value === '') {
+        return;
+    }
+
+    const item = document.createElement('div');
+    item.className = 'memory-context-item';
+
+    const title = document.createElement('strong');
+    title.textContent = label;
+
+    const content = document.createElement('span');
+    if (Array.isArray(value)) {
+        content.innerText = value.join('\n');
+    } else {
+        content.innerText = String(value);
+    }
+
+    item.appendChild(title);
+    item.appendChild(content);
+    container.appendChild(item);
+}
+
+function createMemoryContextSection(memoryData) {
+    if (!memoryData || (typeof memoryData === 'object' && Object.keys(memoryData).length === 0)) {
+        return null;
+    }
+
+    const details = document.createElement('details');
+    details.className = 'memory-context-section';
+
+    const summary = document.createElement('summary');
+    summary.textContent = '已附加記憶與目標';
+    details.appendChild(summary);
+
+    const body = document.createElement('div');
+    body.className = 'memory-context-body';
+
+    appendMemoryContextItem(body, '評分', memoryData['評分']);
+    appendMemoryContextItem(body, '內容評價', memoryData['內容評價']);
+    appendMemoryContextItem(body, '扣分原因', memoryData['扣分原因']);
+    appendMemoryContextItem(body, '改進建議', memoryData['改進建議']);
+
+    const core = memoryData['核心記憶模塊'] || {};
+    appendMemoryContextItem(body, '專案總結', core['專案總結']);
+    appendMemoryContextItem(body, '短期記憶', core['短期記憶']);
+
+    if (Array.isArray(core['長期記憶紀錄'])) {
+        appendMemoryContextItem(body, '長期記憶', core['長期記憶紀錄'].join('\n'));
+    } else {
+        appendMemoryContextItem(body, '長期記憶', core['長期記憶']);
+    }
+
+    const goals = core['專案目標'];
+    if (Array.isArray(goals)) {
+        const goalText = goals.map(goal => {
+            const step = goal['步驟'] || '';
+            const task = goal['任務'] || '';
+            const status = goal['狀態'] || '未開始';
+            return `步驟${step}：${task}（${status}）`;
+        }).join('\n');
+        appendMemoryContextItem(body, '專案目標', goalText);
+    } else {
+        appendMemoryContextItem(body, '專案目標', goals);
+    }
+
+    if (!body.children.length) {
+        return null;
+    }
+
+    details.appendChild(body);
+    return details;
+}
+
+function appendTerminalOutputToMessage(messageElement, terminalText) {
+    if (!messageElement || !terminalText || !terminalText.trim()) {
+        return;
+    }
+
+    let section = messageElement.querySelector('.terminal-output-section');
+    if (!section) {
+        section = document.createElement('div');
+        section.className = 'terminal-output-section';
+        section.innerHTML = `
+            <div class="terminal-header">
+                <span class="terminal-title">Terminal 輸出</span>
+            </div>
+            <div class="terminal-body selectable"></div>
+        `;
+        messageElement.appendChild(section);
+    }
+
+    const body = section.querySelector('.terminal-body');
+    if (body) {
+        body.innerHTML = formatMessageContent(terminalText);
+    }
+}
+
+function buildMemoryPromptFromSnapshot(snapshot) {
+    if (!snapshot) {
+        return '';
+    }
+
+    const core = snapshot['核心記憶模塊'] || {};
+    const goals = Array.isArray(core['專案目標']) ? core['專案目標'] : [];
+    const goalText = goals.map(goal => {
+        const step = goal['步驟'] || goals.indexOf(goal) + 1;
+        const task = goal['任務'] || '';
+        const status = goal['狀態'] || '未開始';
+        return `步驟${step}：${task}（${status}）`;
+    }).join('\n');
+
+    let longTermEntries = [];
+    if (Array.isArray(core['長期記憶紀錄'])) {
+        longTermEntries = core['長期記憶紀錄'];
+    } else if (typeof core['長期記憶'] === 'string') {
+        longTermEntries = core['長期記憶'].split('\n').filter(item => item.trim());
+    }
+
+    const longTermText = longTermEntries.map((entry, index) => `${index + 1}. ${entry}`).join('\n');
+
+    return [
+        '【系統記憶摘要】',
+        `評分：${snapshot['評分'] ?? '--'}`,
+        `內容評價：${snapshot['內容評價'] || '無'}`,
+        `扣分原因：${snapshot['扣分原因'] || '無'}`,
+        `改進建議：${snapshot['改進建議'] || '無'}`,
+        '',
+        '【核心記憶】',
+        `專案總結：${core['專案總結'] || '無'}`,
+        `短期記憶：${core['短期記憶'] || '無'}`,
+        `長期記憶：${longTermText || '無'}`,
+        '專案目標：',
+        goalText || '尚未設定'
+    ].join('\n');
+}
+
+function showConversationLayout() {
+    const layout = document.getElementById('conversationLayout');
+    const results = document.getElementById('resultsContainer');
+    if (layout) {
+        layout.style.display = 'flex';
+    }
+    if (results) {
+        results.style.display = 'block';
+    }
+}
+
+function clearConversationLayout() {
+    const results = document.getElementById('resultsContainer');
+    if (results) {
+        results.innerHTML = '';
+        results.style.display = 'none';
+    }
+    const layout = document.getElementById('conversationLayout');
+    if (layout) {
+        layout.style.display = 'none';
+    }
+}
+
+function renderMemorySnapshot(snapshot) {
+    currentMemorySnapshot = snapshot || null;
+
+    const emptyState = document.getElementById('memoryEmptyState');
+    const scoreSection = document.getElementById('memoryScoreSection');
+    const scoreValue = document.getElementById('memoryScoreValue');
+    const evaluationText = document.getElementById('memoryEvaluationText');
+    const deductionText = document.getElementById('memoryDeductionText');
+    const improvementText = document.getElementById('memoryImprovementText');
+    const summaryText = document.getElementById('memorySummaryText');
+    const shortTermText = document.getElementById('memoryShortTermText');
+    const longTermList = document.getElementById('memoryLongTermList');
+    const goalsContainer = document.getElementById('memoryGoalsList');
+    const updatedAt = document.getElementById('memoryUpdatedAt');
+
+    if (!emptyState || !scoreSection) {
+        return;
+    }
+
+    if (!snapshot) {
+        emptyState.style.display = 'block';
+        scoreSection.style.display = 'none';
+        if (scoreValue) scoreValue.textContent = '--';
+        if (evaluationText) evaluationText.textContent = '請先執行一次請求。';
+        if (deductionText) deductionText.textContent = '無';
+        if (improvementText) improvementText.textContent = '尚無建議。';
+        if (summaryText) summaryText.textContent = '尚未建立摘要。';
+        if (shortTermText) shortTermText.textContent = '尚無記錄。';
+        if (longTermList) {
+            longTermList.innerHTML = '';
+            const li = document.createElement('li');
+            li.textContent = '尚無長期記憶。';
+            longTermList.appendChild(li);
+        }
+        if (goalsContainer) {
+            goalsContainer.innerHTML = '<div class="memory-text">尚未建立專案目標。</div>';
+        }
+        if (updatedAt) updatedAt.textContent = '尚未更新';
+        lastImprovementSuggestion = '';
+        updateMemoryToggleUI();
+        return;
+    }
+
+    emptyState.style.display = 'none';
+    scoreSection.style.display = 'block';
+    if (scoreValue) scoreValue.textContent = snapshot['評分'] != null ? snapshot['評分'] : '--';
+    if (evaluationText) evaluationText.textContent = snapshot['內容評價'] || '無';
+    if (deductionText) deductionText.textContent = snapshot['扣分原因'] || '無';
+    if (improvementText) improvementText.textContent = snapshot['改進建議'] || '無';
+
+    const core = snapshot['核心記憶模塊'] || {};
+    if (summaryText) summaryText.textContent = core['專案總結'] || '尚未建立摘要。';
+    if (shortTermText) shortTermText.textContent = core['短期記憶'] || '尚無記錄。';
+
+    if (longTermList) {
+        longTermList.innerHTML = '';
+        let entries = [];
+        if (Array.isArray(core['長期記憶紀錄'])) {
+            entries = core['長期記憶紀錄'];
+        } else if (typeof core['長期記憶'] === 'string') {
+            entries = core['長期記憶'].split('\n').filter(item => item.trim());
+        }
+        if (!entries.length) {
+            const li = document.createElement('li');
+            li.textContent = '尚無長期記憶。';
+            longTermList.appendChild(li);
+        } else {
+            entries.forEach(entry => {
+                const li = document.createElement('li');
+                li.textContent = entry;
+                longTermList.appendChild(li);
+            });
+        }
+    }
+
+    if (goalsContainer) {
+        goalsContainer.innerHTML = '';
+        const goals = Array.isArray(core['專案目標']) ? core['專案目標'] : [];
+        if (!goals.length) {
+            goalsContainer.innerHTML = '<div class="memory-text">尚未建立專案目標。</div>';
+        } else {
+            goals.forEach(goal => {
+                const item = document.createElement('div');
+                item.className = 'memory-goal-item';
+
+                const header = document.createElement('div');
+                header.className = 'memory-goal-header';
+
+                const step = document.createElement('span');
+                step.textContent = `步驟 ${goal['步驟'] || goals.indexOf(goal) + 1}`;
+                header.appendChild(step);
+
+                const status = document.createElement('span');
+                const statusText = goal['狀態'] || '未開始';
+                status.className = `goal-status ${statusText}`;
+                status.textContent = goal['是否為當前任務'] ? `${statusText}・目前進行` : statusText;
+                header.appendChild(status);
+
+                item.appendChild(header);
+
+                const task = document.createElement('div');
+                task.className = 'memory-goal-task';
+                task.textContent = goal['任務'] || '尚未設定任務';
+                item.appendChild(task);
+
+                goalsContainer.appendChild(item);
+            });
+        }
+    }
+
+    if (updatedAt) {
+        updatedAt.textContent = snapshot['更新時間'] ? new Date(snapshot['更新時間']).toLocaleString('zh-TW') : '尚未更新';
+    }
+
+    lastImprovementSuggestion = snapshot['改進建議'] || '';
+    updateMemoryToggleUI();
+}
+
+function toggleMemoryPanel(forceState = null) {
+    const panel = document.getElementById('memoryPanel');
+    const collapseBtn = document.getElementById('memoryPanelCollapseBtn');
+    if (!panel) {
+        return;
+    }
+
+    const isCollapsed = panel.classList.contains('collapsed');
+    const shouldCollapse = forceState !== null ? forceState : !isCollapsed;
+
+    if (shouldCollapse) {
+        panel.classList.add('collapsed');
+        if (collapseBtn) collapseBtn.classList.add('collapsed');
+    } else {
+        panel.classList.remove('collapsed');
+        if (collapseBtn) collapseBtn.classList.remove('collapsed');
+    }
+}
+
+function updateMemoryToggleUI() {
+    const toggle = document.getElementById('memoryAttachToggle');
+    const status = document.getElementById('memoryAttachStatus');
+    const improvementItem = document.getElementById('lastImprovementMenuItem');
+
+    if (toggle) {
+        toggle.classList.toggle('active', attachMemoryContext);
+    }
+
+    if (status) {
+        status.textContent = attachMemoryContext ? '開啟' : '關閉';
+    }
+
+    if (improvementItem) {
+        improvementItem.style.display = lastImprovementSuggestion ? 'flex' : 'none';
+    }
+}
+
+function toggleMemoryAttachment() {
+    attachMemoryContext = !attachMemoryContext;
+    updateMemoryToggleUI();
+    showNotification(attachMemoryContext ? '已啟用自動附加記憶內容' : '已關閉自動附加記憶內容', attachMemoryContext ? 'success' : 'info');
+    togglePlusMenu();
+}
+
+function insertLastImprovementSuggestion() {
+    if (!lastImprovementSuggestion) {
+        showNotification('目前沒有可插入的改進建議', 'warning');
+        return;
+    }
+
+    const input = document.getElementById('mainInput');
+    if (!input) {
+        return;
+    }
+
+    const suggestionText = `上一輪改進建議：\n${lastImprovementSuggestion}`;
+    if (input.value.trim()) {
+        input.value += `\n\n${suggestionText}`;
+    } else {
+        input.value = suggestionText;
+    }
+
+    updateSubmitButton();
+    autoResize(input);
+    togglePlusMenu();
+    input.focus();
 }
 
 // ============================================
@@ -77,6 +495,10 @@ window.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+
+    renderMemorySnapshot(null);
+    updateMemoryToggleUI();
+    toggleMemoryPanel(false);
 });
 
 // ============================================
@@ -325,9 +747,26 @@ async function handleSubmit() {
     }
 
     document.getElementById('emptyState').style.display = 'none';
-    document.getElementById('resultsContainer').style.display = 'block';
+    showConversationLayout();
 
-    addMessage('user', prompt);
+    const attachmentsForMessage = uploadedFiles.map(file => ({
+        name: file.name,
+        type: file.type
+    }));
+
+    let memoryContext = null;
+    let memoryPromptText = '';
+    if (attachMemoryContext && currentMemorySnapshot) {
+        memoryContext = JSON.parse(JSON.stringify(currentMemorySnapshot));
+        memoryPromptText = buildMemoryPromptFromSnapshot(currentMemorySnapshot);
+    }
+
+    const finalPrompt = memoryPromptText ? `${prompt}\n\n${memoryPromptText}` : prompt;
+
+    addMessage('user', prompt, null, null, {
+        files: attachmentsForMessage,
+        memoryContext
+    });
 
     input.value = '';
     updateSubmitButton();
@@ -343,20 +782,28 @@ async function handleSubmit() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 folder_path: currentProjectDir,
-                prompt: prompt,
+                prompt: finalPrompt,
+                raw_prompt: prompt,
                 config: config,
                 files: uploadedFiles,
                 is_iteration: isIterationMode,
                 attach_screenshot: isIterationMode && autoScreenshot,
-                attach_terminal: attachTerminal
+                attach_terminal: attachTerminal,
+                memory_context: memoryContext
             })
         });
 
         const result = await response.json();
 
         if (result.success) {
-            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output);
-            
+            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output, {
+                metadata: { memory_snapshot: result.memory_snapshot }
+            });
+
+            if (result.memory_snapshot) {
+                renderMemorySnapshot(result.memory_snapshot);
+            }
+
             if (result.project) {
                 currentProject = result.project;
                 if (result.ai_response_json) {
@@ -386,7 +833,10 @@ async function handleSubmit() {
             updateFilesPreview();
             updateAttachedFilesDisplay();
         } else {
-            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`);
+            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`, null, result.terminal_output);
+            if (result.memory_snapshot) {
+                renderMemorySnapshot(result.memory_snapshot);
+            }
             showNotification(`執行失敗：${result.error}`, 'error');
         }
     } catch (error) {
@@ -397,12 +847,13 @@ async function handleSubmit() {
     }
 }
 
-function addMessage(role, content, usageMetadata = null, terminalOutput = null) {
+function addMessage(role, content, usageMetadata = null, terminalOutput = null, options = {}) {
     const container = document.getElementById('resultsContainer');
-    if (!container) return;
-    
+    if (!container) return null;
+
     const message = document.createElement('div');
     message.className = `result-message ${role} selectable`;
+    message.dataset.role = role;
 
     const header = document.createElement('div');
     header.className = 'message-header';
@@ -420,25 +871,28 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
 
     const messageContent = document.createElement('div');
     messageContent.className = 'message-content selectable';
-    messageContent.textContent = content;
+    messageContent.innerHTML = formatMessageContent(content || '');
 
     message.appendChild(header);
     message.appendChild(messageContent);
-    
-    // ✅ Terminal輸出只顯示在用戶消息中
-    if (role === 'user' && terminalOutput && terminalOutput.trim()) {
-        const terminalSection = document.createElement('div');
-        terminalSection.className = 'terminal-output-section';
-        terminalSection.innerHTML = `
-            <div class="terminal-header">
-                <span class="terminal-title">Terminal 輸出</span>
-            </div>
-            <div class="terminal-body selectable">${terminalOutput}</div>
-        `;
-        message.appendChild(terminalSection);
+
+    const files = options.files || options.attachments;
+    const attachmentSection = createAttachmentSection(files);
+    if (attachmentSection) {
+        message.appendChild(attachmentSection);
     }
-    
-    // Token使用統計只顯示在AI回應中
+
+    const metadata = options.metadata || {};
+    const memoryContext = options.memoryContext || metadata['記憶附加'];
+    const memorySection = createMemoryContextSection(memoryContext);
+    if (memorySection) {
+        message.appendChild(memorySection);
+    }
+
+    if (terminalOutput && terminalOutput.trim()) {
+        appendTerminalOutputToMessage(message, terminalOutput);
+    }
+
     if (role === 'assistant' && usageMetadata && typeof usageMetadata === 'object') {
         const tokenUsage = document.createElement('div');
         tokenUsage.className = 'token-usage';
@@ -464,7 +918,8 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
     }
     
     container.appendChild(message);
-    message.scrollIntoView({ behavior: 'smooth' });
+    message.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    return message;
 }
 
 function useSuggestion(text) {
@@ -508,12 +963,13 @@ async function createNewProject() {
             uploadedFiles = [];
             updateFilesPreview();
             updateAttachedFilesDisplay();
-            
+
             document.getElementById('projectStructureSection').style.display = 'none';
             document.getElementById('emptyState').style.display = 'none';
-            document.getElementById('resultsContainer').style.display = 'block';
+            showConversationLayout();
             document.getElementById('resultsContainer').innerHTML = '';
-            
+            renderMemorySnapshot(null);
+
             showNotification('已選擇專案資料夾', 'success');
             document.getElementById('mainInput')?.focus();
         } else {
@@ -550,16 +1006,16 @@ async function selectExistingFolder() {
                     badge.textContent = '延續';
                     badge.style.background = '#0ea5e9';
                 }
-                
+
                 document.getElementById('homeBtn').style.display = 'flex';
-                
+
                 document.querySelectorAll('.project-item').forEach(item => {
                     item.classList.remove('active');
                 });
-                
+
                 document.getElementById('emptyState').style.display = 'none';
-                document.getElementById('resultsContainer').style.display = 'block';
-                
+                showConversationLayout();
+
                 showNotification(`已載入專案: ${currentProject.name}`, 'success');
             } else {
                 showNotification('此資料夾不是有效的專案，將作為新專案', 'warning');
@@ -571,9 +1027,12 @@ async function selectExistingFolder() {
                     badge.textContent = '新建';
                     badge.style.background = '#10a37f';
                 }
-                
+
                 document.getElementById('homeBtn').style.display = 'flex';
                 document.getElementById('projectStructureSection').style.display = 'none';
+                renderMemorySnapshot(null);
+                showConversationLayout();
+                document.getElementById('resultsContainer').innerHTML = '';
             }
             
             document.getElementById('mainInput')?.focus();
@@ -669,17 +1128,17 @@ async function selectProject(project) {
         item.classList.remove('active');
     });
     event.target.closest('.project-item')?.classList.add('active');
-    
+
     document.getElementById('emptyState').style.display = 'none';
-    document.getElementById('resultsContainer').style.display = 'block';
+    showConversationLayout();
     document.getElementById('resultsContainer').innerHTML = '';
-    
+
     uploadedFiles = [];
     updateFilesPreview();
     updateAttachedFilesDisplay();
-    
+
     await loadExistingProject(project.path);
-    
+
     showNotification(`已切換到專案: ${project.name}`, 'success');
 }
 
@@ -693,7 +1152,7 @@ async function loadExistingProject(projectDir) {
         });
         
         const result = await response.json();
-        
+
         if (result.success) {
             currentProject = {
                 name: result.project_info.project_name,
@@ -710,18 +1169,62 @@ async function loadExistingProject(projectDir) {
             
             document.getElementById('currentProjectName').textContent = currentProject.name;
             displayProjectStructure(result.project_info.files);
-            
-            if (result.conversation && result.conversation.messages) {
-                const container = document.getElementById('resultsContainer');
-                if (container) {
-                    container.innerHTML = '';
-                    
-                    for (const msg of result.conversation.messages) {
-                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output);
+
+            const container = document.getElementById('resultsContainer');
+            if (container) {
+                container.innerHTML = '';
+            }
+            showConversationLayout();
+
+            if (result.conversation && result.conversation.messages && container) {
+                let bufferedTerminalOutput = null;
+                let bufferedUserElement = null;
+
+                for (const msg of result.conversation.messages) {
+                    const options = {
+                        files: msg.files,
+                        metadata: msg.metadata
+                    };
+
+                    if (msg.role === 'user') {
+                        bufferedUserElement = addMessage(msg.role, msg.content, msg.usage_metadata, null, options);
+                        if (msg.terminal_output && msg.terminal_output.trim()) {
+                            bufferedTerminalOutput = msg.terminal_output;
+                        } else {
+                            bufferedTerminalOutput = null;
+                        }
+                        continue;
+                    }
+
+                    let terminalPayload = msg.terminal_output;
+                    if ((!terminalPayload || !terminalPayload.trim()) && bufferedTerminalOutput) {
+                        terminalPayload = bufferedTerminalOutput;
+                    }
+
+                    addMessage(msg.role, msg.content, msg.usage_metadata, terminalPayload, options);
+
+                    const hasTerminalPayload = terminalPayload && terminalPayload.trim();
+                    if (msg.role === 'assistant' && hasTerminalPayload) {
+                        bufferedTerminalOutput = null;
+                        bufferedUserElement = null;
+                    } else if (!hasTerminalPayload && bufferedTerminalOutput && bufferedUserElement) {
+                        appendTerminalOutputToMessage(bufferedUserElement, bufferedTerminalOutput);
+                        bufferedTerminalOutput = null;
+                        bufferedUserElement = null;
                     }
                 }
+
+                if (bufferedTerminalOutput && bufferedUserElement) {
+                    appendTerminalOutputToMessage(bufferedUserElement, bufferedTerminalOutput);
+                }
             }
-            
+
+            if (result.memory_snapshot) {
+                renderMemorySnapshot(result.memory_snapshot);
+            } else {
+                renderMemorySnapshot(null);
+            }
+
             return true;
         } else {
             return false;
@@ -824,14 +1327,17 @@ function resetToHome() {
     currentProject = null;
     isIterationMode = false;
     uploadedFiles = [];
-    
+
+    clearConversationLayout();
+    renderMemorySnapshot(null);
+    lastImprovementSuggestion = '';
+    updateMemoryToggleUI();
+
     document.getElementById('currentProjectDisplay').style.display = 'none';
     document.getElementById('emptyState').style.display = 'flex';
-    document.getElementById('resultsContainer').style.display = 'none';
-    document.getElementById('resultsContainer').innerHTML = '';
     document.getElementById('projectStructureSection').style.display = 'none';
     document.getElementById('homeBtn').style.display = 'none';
-    
+
     document.querySelectorAll('.project-item').forEach(item => {
         item.classList.remove('active');
     });

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -375,6 +375,292 @@ body {
     padding: 24px;
 }
 
+.conversation-layout {
+    width: 100%;
+    max-width: 1200px;
+    display: flex;
+    gap: 24px;
+    align-items: flex-start;
+}
+
+.conversation-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.memory-column {
+    width: 340px;
+    position: relative;
+}
+
+.memory-panel {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    border-radius: 12px;
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+    position: sticky;
+    top: 96px;
+    max-height: calc(100vh - 180px);
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.memory-panel.collapsed {
+    transform: translateX(20px) scale(0.96);
+    opacity: 0;
+    pointer-events: none;
+}
+
+.memory-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-light);
+}
+
+.memory-panel-title h3 {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.memory-panel-title .memory-updated {
+    display: block;
+    margin-top: 4px;
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.collapse-memory-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.collapse-memory-btn svg {
+    transition: transform 0.2s ease;
+}
+
+.collapse-memory-btn.collapsed svg {
+    transform: rotate(180deg);
+}
+
+.collapse-memory-btn:hover {
+    background: var(--bg-tertiary);
+}
+
+.memory-panel-body {
+    padding: 16px 20px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    overflow-y: auto;
+}
+
+.memory-empty {
+    border: 1px dashed var(--border-color);
+    border-radius: 8px;
+    padding: 12px;
+    font-size: 13px;
+    color: var(--text-secondary);
+    text-align: center;
+    display: none;
+}
+
+.memory-score-section {
+    text-align: center;
+    padding: 16px 12px;
+    border-radius: 12px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-light);
+}
+
+.memory-score-value {
+    font-size: 32px;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.memory-score-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+    letter-spacing: 1px;
+    margin-top: 4px;
+}
+
+.memory-text-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.memory-text-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.memory-text {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+}
+
+.memory-pre {
+    font-size: 12px;
+    line-height: 1.6;
+    font-family: 'JetBrains Mono', 'Cascadia Code', Menlo, monospace;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    padding: 12px;
+    color: var(--text-primary);
+}
+
+.memory-list {
+    list-style: none;
+    padding-left: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.memory-list li {
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    position: relative;
+    padding-left: 16px;
+}
+
+.memory-list li::before {
+    content: '•';
+    position: absolute;
+    left: 0;
+    color: var(--primary-color);
+}
+
+.memory-divider {
+    height: 1px;
+    background: var(--border-light);
+}
+
+.memory-goals {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.memory-goal-item {
+    border: 1px solid var(--border-light);
+    border-radius: 10px;
+    padding: 12px;
+    background: var(--bg-secondary);
+}
+
+.memory-goal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+}
+
+.memory-goal-task {
+    font-size: 13px;
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+.goal-status {
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.goal-status.已完成 {
+    background: rgba(16, 163, 127, 0.12);
+    color: #0d8b68;
+}
+
+.goal-status.進行中 {
+    background: rgba(14, 165, 233, 0.12);
+    color: #0ea5e9;
+}
+
+.goal-status.未開始 {
+    background: rgba(148, 163, 184, 0.2);
+    color: #475569;
+}
+
+.memory-panel-floating-toggle {
+    position: sticky;
+    bottom: 40px;
+    left: calc(100% + 16px);
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: none;
+    background: var(--primary-color);
+    color: #ffffff;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--shadow-md);
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.memory-panel-floating-toggle:hover {
+    background: var(--primary-hover);
+}
+
+.memory-panel.collapsed + .memory-panel-floating-toggle {
+    display: flex;
+}
+
+@media (max-width: 1200px) {
+    .conversation-layout {
+        flex-direction: column;
+        max-width: 900px;
+    }
+
+    .memory-column {
+        width: 100%;
+    }
+
+    .memory-panel {
+        position: relative;
+        top: 0;
+        max-height: none;
+    }
+
+    .memory-panel.collapsed {
+        transform: none;
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .memory-panel-floating-toggle {
+        display: none !important;
+    }
+}
+
 .empty-state {
     max-width: 900px;
     width: 100%;
@@ -752,6 +1038,55 @@ body {
     color: var(--text-primary);
 }
 
+.menu-item.menu-toggle {
+    justify-content: space-between;
+}
+
+.menu-toggle-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.menu-toggle-text span {
+    font-weight: 500;
+}
+
+.menu-toggle-text small {
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.menu-toggle-indicator {
+    width: 34px;
+    height: 18px;
+    border-radius: 999px;
+    background: var(--border-color);
+    position: relative;
+    transition: background 0.2s ease;
+}
+
+.menu-toggle-indicator::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #ffffff;
+    transition: transform 0.2s ease;
+    box-shadow: var(--shadow-sm);
+}
+
+.menu-item.menu-toggle.active .menu-toggle-indicator {
+    background: var(--primary-color);
+}
+
+.menu-item.menu-toggle.active .menu-toggle-indicator::after {
+    transform: translateX(16px);
+}
+
 .menu-item:hover {
     background: var(--bg-secondary);
 }
@@ -816,7 +1151,7 @@ body {
 .results-container {
     max-width: 900px;
     width: 100%;
-    margin: 0 auto;
+    margin: 0;
     padding: 20px;
 }
 
@@ -888,6 +1223,97 @@ body {
 
 .token-value {
     font-weight: 600;
+    color: var(--text-primary);
+}
+
+.attachments-section {
+    margin-top: 12px;
+    border: 1px solid var(--border-light);
+    border-radius: 10px;
+    overflow: hidden;
+    background: var(--bg-primary);
+}
+
+.attachments-header {
+    padding: 8px 12px;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-light);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    display: flex;
+    justify-content: space-between;
+}
+
+.attachments-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+}
+
+.attachment-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text-primary);
+}
+
+.attachment-icon {
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    background: var(--bg-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.memory-context-section {
+    margin-top: 12px;
+    border: 1px solid var(--border-light);
+    border-radius: 10px;
+    background: var(--bg-secondary);
+    overflow: hidden;
+}
+
+.memory-context-section summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 10px 14px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+    background: rgba(16, 163, 127, 0.12);
+}
+
+.memory-context-section summary::-webkit-details-marker {
+    display: none;
+}
+
+.memory-context-section[open] summary {
+    border-bottom: 1px solid var(--border-light);
+}
+
+.memory-context-body {
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-context-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.memory-context-item strong {
     color: var(--text-primary);
 }
 

--- a/vscode_controller_project3-1/templates/index.html
+++ b/vscode_controller_project3-1/templates/index.html
@@ -179,7 +179,67 @@
                 </div>
             </div>
 
-            <div class="results-container" id="resultsContainer" style="display: none;"></div>
+            <div class="conversation-layout" id="conversationLayout" style="display: none;">
+                <div class="conversation-main">
+                    <div class="results-container" id="resultsContainer" style="display: none;"></div>
+                </div>
+                <div class="memory-column">
+                    <div class="memory-panel" id="memoryPanel">
+                        <div class="memory-panel-header">
+                            <div class="memory-panel-title">
+                                <h3>記憶與自評</h3>
+                                <span class="memory-updated" id="memoryUpdatedAt">尚未更新</span>
+                            </div>
+                            <button class="collapse-memory-btn" id="memoryPanelCollapseBtn" onclick="toggleMemoryPanel()" title="收合或展開記憶面板">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <polyline points="6 9 12 15 18 9"/>
+                                </svg>
+                            </button>
+                        </div>
+                        <div class="memory-panel-body" id="memoryPanelBody">
+                            <div class="memory-empty" id="memoryEmptyState">尚未載入記憶資料。</div>
+                            <div class="memory-score-section" id="memoryScoreSection">
+                                <div class="memory-score-value" id="memoryScoreValue">--</div>
+                                <div class="memory-score-label">本輪評分</div>
+                            </div>
+                            <div class="memory-text-section">
+                                <div class="memory-text-title">內容評價</div>
+                                <p class="memory-text" id="memoryEvaluationText">請先執行一次請求。</p>
+                            </div>
+                            <div class="memory-text-section">
+                                <div class="memory-text-title">扣分原因</div>
+                                <p class="memory-text" id="memoryDeductionText">無</p>
+                            </div>
+                            <div class="memory-text-section">
+                                <div class="memory-text-title">改進建議</div>
+                                <p class="memory-text" id="memoryImprovementText">尚無建議。</p>
+                            </div>
+                            <div class="memory-divider"></div>
+                            <div class="memory-text-section">
+                                <div class="memory-text-title">專案總結</div>
+                                <p class="memory-text" id="memorySummaryText">尚未建立摘要。</p>
+                            </div>
+                            <div class="memory-text-section">
+                                <div class="memory-text-title">短期記憶</div>
+                                <pre class="memory-pre" id="memoryShortTermText">尚無記錄。</pre>
+                            </div>
+                            <div class="memory-text-section">
+                                <div class="memory-text-title">長期記憶</div>
+                                <ul class="memory-list" id="memoryLongTermList"></ul>
+                            </div>
+                            <div class="memory-text-section">
+                                <div class="memory-text-title">專案目標</div>
+                                <div class="memory-goals" id="memoryGoalsList"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <button class="memory-panel-floating-toggle" id="memoryPanelFloatingToggle" onclick="toggleMemoryPanel()" title="展開記憶面板">
+                        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 12h16M10 6l-6 6 6 6"/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
         </div>
 
         <div class="input-area">
@@ -216,6 +276,19 @@
                                     <line x1="12" y1="19" x2="20" y2="19"/>
                                 </svg>
                                 <span>附加 Terminal 輸出</span>
+                            </div>
+                            <div class="menu-item menu-toggle" id="memoryAttachToggle" onclick="toggleMemoryAttachment()">
+                                <div class="menu-toggle-text">
+                                    <span>自動附加記憶與目標</span>
+                                    <small id="memoryAttachStatus">開啟</small>
+                                </div>
+                                <div class="menu-toggle-indicator"></div>
+                            </div>
+                            <div class="menu-item" id="lastImprovementMenuItem" onclick="insertLastImprovementSuggestion()" style="display: none;">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 5v14M5 12h14"/>
+                                </svg>
+                                <span>插入上一輪改進建議</span>
                             </div>
                             <div class="menu-divider"></div>
                             <div class="menu-item" onclick="showAdvancedSettings()">


### PR DESCRIPTION
## 摘要
- 新增 MemoryManager，於後端為每個專案生成長短期記憶、評分與改進建議並回傳前端
- 擴充 /run-process 與 /load-project API，回傳最新記憶快照並保存使用者記憶上下文
- 更新前端 UI，加入可收合的記憶面板、記憶自動附加切換與上一輪建議插入功能
- 修復對話當下 terminal 輸出及附件顯示問題，支援歷史紀錄重現

## 測試
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e8eb58d1548329a3638afe9bf55ffc