### PR TITLE
Add diagnostics toggle and lateral memory panel interactions

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -17,6 +17,10 @@ import json
 import platform
 import logging
 import queue
+import ast
+import shutil
+import tempfile
+import xml.etree.ElementTree as ET
 from typing import Dict, List, Optional, Tuple, Any
 from datetime import datetime
 from pathlib import Path
@@ -194,6 +198,8 @@ class ProjectConversation:
     messages: List[ConversationMessage] = field(default_factory=list)
     created_at: str = ""
     updated_at: str = ""
+    memory_snapshot: Dict[str, Any] = field(default_factory=dict)
+    evaluation_snapshot: Dict[str, Any] = field(default_factory=dict)
 
 @dataclass
 class ProcessResult:
@@ -211,6 +217,9 @@ class ProcessResult:
     is_iteration: bool = False
     usage_metadata: Optional[Dict] = None
     terminal_output: str = ""
+    memory_snapshot: Optional[Dict[str, Any]] = None
+    evaluation_snapshot: Optional[Dict[str, Any]] = None
+    diagnostics: List[Dict[str, Any]] = field(default_factory=list)
 
 # ============================================
 # JSON Schema 定義 - 繁體中文化
@@ -221,141 +230,135 @@ def get_json_schema():
     return {
         "type": "object",
         "properties": {
-            "project_name": {"type": "string", "description": "專案名稱"},
-            "description": {"type": "string", "description": "專案描述"},
-            "main_file": {"type": "string", "description": "主要執行檔案"},
-            "setup_instructions": {"type": "array", "items": {"type": "string"}, "description": "設置指令"},
-            "run_instructions": {"type": "array", "items": {"type": "string"}, "description": "執行指令"},
-            "files": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "filename": {"type": "string", "description": "檔案名稱(含副檔名)"},
-                        "filetype": {
-                            "type": "string",
-                            "enum": ["python", "javascript", "html", "css", "typescript", "java", "cpp", "c", "go", "rust", "ruby", "php", "swift", "kotlin", "sql", "shell", "yaml", "json", "xml", "markdown", "text"],
-                            "description": "檔案類型"
+            "評分": {"type": "integer", "minimum": 0, "maximum": 100, "description": "請針對本次回應品質給出 0-100 分的整數評分"},
+            "內容評價": {"type": "string", "description": "200 字以內的簡短評論,需涵蓋規則遵守與內容品質"},
+            "扣分原因": {"type": "string", "description": "若評分未滿分,需具體指出扣分原因,否則填寫『無』"},
+            "改進建議": {"type": "string", "description": "列出下次回覆可改進之處,若無則填寫『無』"},
+            "核心記憶模塊": {
+                "type": "object",
+                "description": "保存長短期記憶與專案目標的模塊",
+                "properties": {
+                    "專案總結": {"type": "string", "description": "概述目前專案或對話重點"},
+                    "短期記憶": {"type": "string", "description": "近期對話中與當前任務最相關的資訊，請使用條列式"},
+                    "長期記憶": {"type": "string", "description": "專案長期背景、核心目標或重要限制，請使用條列式"},
+                    "專案目標": {
+                        "type": "array",
+                        "description": "依序列出至少四個專案目標與狀態",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "步驟": {"type": "integer", "description": "目標步驟編號"},
+                                "任務": {"type": "string", "description": "具體任務描述"},
+                                "狀態": {"type": "string", "enum": ["未開始", "進行中", "已完成"], "description": "任務狀態"},
+                                "是否為當前任務": {"type": "boolean", "description": "此任務是否為目前主要工作"}
+                            },
+                            "required": ["步驟", "任務", "狀態", "是否為當前任務"]
                         },
-                        "code": {"type": "string", "description": "完整程式碼內容"},
-                        "opens_window": {"type": "boolean", "description": "是否會開啟視窗"},
-                        "window_title": {"type": ["string", "null"], "description": "視窗標題(如果有)"},
-                        "install_requirements": {"type": "array", "items": {"type": "string"}, "description": "安裝需求(如 pip install package)"},
-                        "dependencies": {"type": "array", "items": {"type": "string"}, "description": "相依套件"},
-                        "description": {"type": "string", "description": "檔案描述"},
-                        "run_command": {"type": ["string", "null"], "description": "執行命令"},
-                        "is_web_app": {"type": "boolean", "description": "是否為網頁應用"},
-                        "can_open_standalone": {"type": "boolean", "description": "主程式是否能自動開啟獨立瀏覽器視窗"},
-                        "server_address": {"type": ["string", "null"], "description": "伺服器地址(如 http://localhost:5000)"},
-                        "web_title": {"type": ["string", "null"], "description": "網頁標題"}
-                    },
-                    "required": ["filename", "filetype", "code", "opens_window"]
-                }
+                        "minItems": 4
+                    }
+                },
+                "required": ["專案總結", "短期記憶", "長期記憶", "專案目標"]
+            },
+            "專案輸出": {
+                "type": "object",
+                "description": "包含完整程式碼與操作資訊的區塊",
+                "properties": {
+                    "project_name": {"type": "string", "description": "專案名稱"},
+                    "description": {"type": "string", "description": "專案描述"},
+                    "main_file": {"type": "string", "description": "主要執行檔案"},
+                    "setup_instructions": {"type": "array", "items": {"type": "string"}, "description": "設置指令"},
+                    "run_instructions": {"type": "array", "items": {"type": "string"}, "description": "執行指令"},
+                    "files": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "filename": {"type": "string", "description": "檔案名稱(含副檔名)"},
+                                "filetype": {
+                                    "type": "string",
+                                    "enum": ["python", "javascript", "html", "css", "typescript", "java", "cpp", "c", "go", "rust", "ruby", "php", "swift", "kotlin", "sql", "shell", "yaml", "json", "xml", "markdown", "text"],
+                                    "description": "檔案類型"
+                                },
+                                "code": {"type": "string", "description": "完整程式碼內容"},
+                                "opens_window": {"type": "boolean", "description": "是否會開啟視窗"},
+                                "window_title": {"type": ["string", "null"], "description": "視窗標題(如果有)"},
+                                "install_requirements": {"type": "array", "items": {"type": "string"}, "description": "安裝需求(如 pip install package)"},
+                                "dependencies": {"type": "array", "items": {"type": "string"}, "description": "相依套件"},
+                                "description": {"type": "string", "description": "檔案描述"},
+                                "run_command": {"type": ["string", "null"], "description": "執行命令"},
+                                "is_web_app": {"type": "boolean", "description": "是否為網頁應用"},
+                                "can_open_standalone": {"type": "boolean", "description": "主程式是否能自動開啟獨立瀏覽器視窗"},
+                                "server_address": {"type": ["string", "null"], "description": "伺服器地址(如 http://localhost:5000)"},
+                                "web_title": {"type": ["string", "null"], "description": "網頁標題"}
+                            },
+                            "required": ["filename", "filetype", "code", "opens_window"]
+                        }
+                    }
+                },
+                "required": ["project_name", "description", "files"]
             }
         },
-        "required": ["project_name", "description", "files"]
+        "required": ["評分", "內容評價", "扣分原因", "改進建議", "核心記憶模塊", "專案輸出"]
     }
 
 def get_json_system_instruction():
     """獲取 JSON 模式的系統指令 - 繁體中文版 + Flask修復"""
-    return """你是一位專業的程式碼助手,能夠生成完整、可運行的專案程式碼。
+    return """你是一位專業的程式碼與專案助理,負責在每次回應中同時提供程式碼成果、評分與記憶管理資訊。
 
-回應時,你必須輸出一個符合以下結構的有效 JSON 物件:
+請務必輸出**單一 JSON 物件**,其欄位結構如下:
 {
-    "project_name": "描述性的專案名稱",
-    "description": "專案功能的簡要描述",
-    "main_file": "main.py",
-    "setup_instructions": ["pip install package1", "pip install package2"],
-    "run_instructions": ["python main.py", "開啟瀏覽器前往 http://localhost:5000"],
-    "files": [
-        {
-            "filename": "main.py",
-            "filetype": "python",
-            "code": "import flask\\n\\napp = flask.Flask(__name__)\\n\\n@app.route('/')\\ndef home():\\n    return 'Hello World'\\n\\nif __name__ == '__main__':\\n    app.run(host='0.0.0.0', port=5000)",
-            "opens_window": false,
-            "window_title": null,
-            "install_requirements": ["pip install flask"],
-            "dependencies": ["flask"],
-            "description": "主應用程式檔案",
-            "run_command": "python main.py",
-            "is_web_app": true,
-            "can_open_standalone": false,
-            "server_address": "http://localhost:5000",
-            "web_title": "我的網頁應用"
-        }
-    ]
+  "評分": 0-100 的整數,
+  "內容評價": "200 字內的綜合評論",
+  "扣分原因": "若無扣分請填『無』",
+  "改進建議": "下一次回應可改進的方向,若無請填『無』",
+  "核心記憶模塊": {
+      "專案總結": "摘要最新對話或專案重點",
+      "短期記憶": "以條列式整理最近幾輪對話中的關鍵資訊(可用 1./2. 或 - 作為項目符號)",
+      "長期記憶": "以條列式整理專案背景、核心目標或重要限制",
+      "專案目標": [
+          {"步驟": 1, "任務": "...", "狀態": "已完成/進行中/未開始", "是否為當前任務": true/false},
+          {"步驟": 2, ... 至少四個項目 }
+      ]
+  },
+  "專案輸出": {
+      "project_name": "專案名稱",
+      "description": "簡要描述",
+      "main_file": "主要程式檔案名稱",
+      "setup_instructions": ["pip install package1"...],
+      "run_instructions": ["python main.py"...],
+      "files": [
+          {
+              "filename": "檔案名稱(含副檔名)",
+              "filetype": "python/javascript/...",
+              "code": "完整無省略程式碼,使用實際換行符號",
+              "opens_window": true/false,
+              "window_title": null 或字串,
+              "install_requirements": ["pip install ..."],
+              "dependencies": ["flask", "numpy"...],
+              "description": "檔案用途說明",
+              "run_command": "python main.py" 或 null,
+              "is_web_app": true/false,
+              "can_open_standalone": true/false,
+              "server_address": "http://localhost:5000" 或 null,
+              "web_title": "網頁標題" 或 null
+          }
+      ]
+  }
 }
 
-重要格式要則:
-1. "code" 欄位必須包含正確格式化的程式碼,使用真實的換行符號和縮排
-2. 在 code 字串中使用實際的換行字元 (\\n) 和 Tab 字元 (\\t),不是文字上的 \\n 字串
-3. 程式碼必須是有效的 JSON 字串 - 正確跳脫引號
-4. 確保程式碼中的縮排正確保留
-5. 程式碼的每一行應該在 JSON 字串中獨立成行
+嚴格遵守以下規範:
+1. 僅能輸出有效 JSON,不得加入多餘文字、註解或 Markdown。
+2. "files" 內的程式碼必須為完整、可執行、無省略號的繁體中文註解或文字,並以真實 \n 代表換行、\t 代表縮排。
+3. 若為 Flask/Node 等伺服器程式,禁止使用 debug=True 或熱重載模式,Flask 必須採用 `app.run(host='0.0.0.0', port=5000)`。
+4. 所有網頁相關檔案需填寫 `is_web_app`, 並在必要時提供 `server_address` 與 `web_title`。
+5. 任何需要額外套件的檔案,必須在 `install_requirements` 中完整列出安裝指令。
+6. 多檔案專案需確保相依檔案之間的匯入路徑正確,不得遺漏必要資源。
+7. 所有字串請使用繁體中文說明,除非程式語言語法或函式庫名稱要求英文。
+8. 專案目標需依進度更新狀態,並清楚標示當前主要任務。
+9. 評分、扣分原因、改進建議需與本次回覆內容一致,不得空泛。
+10. 若提示中提供「語法偵錯結果」區塊,請優先修正其中提及的問題,並於回覆中說明修正方式。
 
-**CRITICAL Flask/Web Server 要則:**
-1. **絕對禁止使用 debug=True** - 這會導致在 subprocess 中運行時崩潰
-2. Flask 應用必須使用:`app.run(host='0.0.0.0', port=5000)` (不帶 debug 參數)
-3. Node.js/Express 應用也不要使用開發模式的熱重載
-4. 如果需要開發便利性,可以在代碼註釋中說明手動運行時可加 debug=True
-
-網頁應用要則:
-1. 對於 HTML 檔案或伺服器應用程式(Flask、Node.js 等),設定 "is_web_app": true
-2. 只有在你的程式碼包含自動開啟瀏覽器功能時,才設定 "can_open_standalone": true:
-   - Python: 使用 webbrowser.open() 或 Flask 加上 app.run(port=5000) + webbrowser
-   - Node.js: 使用 'open' 套件或類似工具
-   - HTML: 如果是可以直接開啟的獨立 HTML
-3. 如果 "can_open_standalone" 為 false 但 "is_web_app" 為 true,請提供:
-   - "server_address": 應用程式將運行的 URL(例如:"http://localhost:5000")
-   - "web_title": 網頁的標題
-4. 對於獨立的 HTML 檔案,將 opens_window 和 is_web_app 都設為 true
-5. 對於伺服器應用程式,控制器將處理開啟獨立瀏覽器視窗
-
-重要要則:
-1. 始終生成完整、可運行的程式碼 - 不要使用佔位符或省略號
-2. 對於 GUI 應用程式(pygame/tkinter),設定視窗標題以匹配專案名稱
-3. 對於網頁應用,確保 HTML 有適當的 <title> 標籤
-4. 包含所有必要的匯入和錯誤處理
-5. 正確指定檔案類型(python、javascript、html 等)
-6. 對於 GUI 應用程式或獨立 HTML 檔案,將 opens_window 設為 true
-7. 在 install_requirements 中列出所有套件安裝命令
-8. 為每個檔案提供清晰的描述
-9. 對於多檔案專案,確保檔案正確連結
-
-支持的檔案類型:
-python, javascript, html, css, typescript, java, cpp, c, go, rust, ruby, php, swift, kotlin, sql, shell, yaml, json, xml, markdown, text
-
-記住:
-- 只輸出有效的 JSON,不要有額外的文字或 markdown 格式
-- 確保程式碼正確格式化,縮排正確
-- 在程式碼字串中使用真實的換行符號,而不是 \\n 文字
-- 對於網頁應用,仔細考慮獨立瀏覽器視窗的能力
-- **Flask/Web 伺服器絕對不要使用 debug=True**
-
-對於 HTML + 後端專案的特別注意事項:
-1. 確保後端伺服器(Flask/Node.js)正確配置 CORS 和靜態檔案服務
-2. HTML 檔案應該正確引用後端 API 端點
-3. 提供完整的前後端連接測試程式碼
-4. 在 run_instructions 中明確說明:
-   - 先啟動後端伺服器
-   - 後端服務地址
-   - 前端如何訪問
-5. 對於需要同時運行前後端的專案:
-   - 後端檔案設定 is_web_app: true, can_open_standalone: false
-   - 提供準確的 server_address 和 web_title
-   - 確保後端程式碼包含適當的路由和 CORS 設定
-   - **後端絕對不要使用 debug=True**
-6. 測試程式碼應該驗證:
-   - 後端伺服器啟動成功
-   - API 端點可訪問
-   - 前後端數據交互正常
-
-Terminal 輸出和除錯資訊:
-1. 所有重要的執行步驟都應該有 print() 或 console.log() 輸出
-2. 包含適當的錯誤處理和錯誤訊息輸出
-3. 啟動時輸出服務地址和狀態資訊
-4. 對於網頁應用,輸出 "伺服器運行於: http://localhost:PORT"
-"""
+請以這個全新結構回覆,不要沿用舊版模板或刪減任何必要欄位。"""
 
 # ============================================
 # 配置管理模塊
@@ -429,7 +432,7 @@ class ConversationManager:
     def load_conversation(project_dir: str) -> ProjectConversation:
         """載入專案對話歷史 - 正確處理 usage_metadata"""
         conv_file = ConversationManager.get_conversation_file(project_dir)
-        
+
         if not conv_file.exists():
             project_name = Path(project_dir).name
             conv = ProjectConversation(
@@ -466,7 +469,9 @@ class ConversationManager:
                     project_name=data['project_name'],
                     messages=messages,
                     created_at=data.get('created_at', ''),
-                    updated_at=data.get('updated_at', '')
+                    updated_at=data.get('updated_at', ''),
+                    memory_snapshot=data.get('memory_snapshot', {}),
+                    evaluation_snapshot=data.get('evaluation_snapshot', {})
                 )
         except Exception as e:
             logger.error(f"載入對話歷史失敗: {e}")
@@ -503,9 +508,11 @@ class ConversationManager:
                 'project_name': conversation.project_name,
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'memory_snapshot': conversation.memory_snapshot,
+                'evaluation_snapshot': conversation.evaluation_snapshot
             }
-            
+
             with open(conv_file, 'w', encoding='utf-8') as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
             
@@ -533,6 +540,20 @@ class ConversationManager:
         )
         
         conversation.messages.append(message)
+        ConversationManager.save_conversation(conversation)
+
+    @staticmethod
+    def update_memory_state(project_dir: str, memory_snapshot: Optional[Dict], evaluation_snapshot: Optional[Dict]):
+        """更新對話的記憶與評分快照"""
+        conversation = ConversationManager.load_conversation(project_dir)
+
+        if memory_snapshot:
+            conversation.memory_snapshot = memory_snapshot
+        if evaluation_snapshot:
+            conversation.evaluation_snapshot = {
+                k: v for k, v in (evaluation_snapshot or {}).items() if v is not None
+            }
+
         ConversationManager.save_conversation(conversation)
     
     @staticmethod
@@ -674,15 +695,323 @@ class ProjectManager:
         try:
             project_list = ProjectManager.get_project_list()
             project_list = [p for p in project_list if p['path'] != project_dir]
-            
+
             with open(PROJECT_LIST_FILE, 'w', encoding='utf-8') as f:
                 json.dump(project_list, f, indent=2, ensure_ascii=False)
-            
+
             logger.info(f"已從列表移除專案: {project_dir}")
             return True
         except Exception as e:
             logger.error(f"移除專案失敗: {e}")
             return False
+
+# ============================================
+# 語法偵錯模塊
+# ============================================
+
+class DiagnosticsManager:
+    """多語言語法偵錯管理器"""
+
+    NODE_CMD = shutil.which('node')
+    TSC_CMD = shutil.which('tsc')
+
+    @staticmethod
+    def generate(files: List[Dict]) -> List[Dict[str, Any]]:
+        diagnostics: List[Dict[str, Any]] = []
+        seen: set = set()
+
+        for file_data in files or []:
+            try:
+                file_name = file_data.get('name') or file_data.get('filename')
+                if not file_name:
+                    continue
+
+                if file_name in seen:
+                    continue
+                seen.add(file_name)
+
+                mime_type = (file_data.get('type') or '').lower()
+                content = file_data.get('content')
+
+                if not isinstance(content, str):
+                    diagnostics.append({
+                        'file': file_name,
+                        'status': 'skipped',
+                        'message': '此檔案非純文字內容，已略過語法偵錯。'
+                    })
+                    continue
+
+                if content.startswith('data:'):
+                    diagnostics.append({
+                        'file': file_name,
+                        'status': 'skipped',
+                        'message': '偵測到二進位資料(如圖片或 PDF)，略過語法偵錯。'
+                    })
+                    continue
+
+                if not content.strip():
+                    diagnostics.append({
+                        'file': file_name,
+                        'status': 'warning',
+                        'message': '檔案內容為空白，請確認是否遺漏程式碼。'
+                    })
+                    continue
+
+                diagnostics.append(
+                    DiagnosticsManager.inspect_file(file_name, content, mime_type)
+                )
+            except Exception as diag_error:
+                diagnostics.append({
+                    'file': file_data.get('name') or file_data.get('filename') or '未知檔案',
+                    'status': 'warning',
+                    'message': f'語法偵錯時發生例外: {diag_error}'
+                })
+
+        return diagnostics
+
+    @staticmethod
+    def inspect_file(file_name: str, content: str, mime_type: str) -> Dict[str, Any]:
+        ext = Path(file_name).suffix.lower()
+
+        if mime_type == 'application/json' or ext == '.json':
+            return DiagnosticsManager.check_json(file_name, content)
+        if mime_type == 'application/xml' or ext == '.xml':
+            return DiagnosticsManager.check_xml(file_name, content)
+        if ext in {'.yaml', '.yml'}:
+            return DiagnosticsManager.check_yaml(file_name, content)
+        if ext in {'.py'}:
+            return DiagnosticsManager.check_python(file_name, content)
+        if ext in {'.js', '.mjs', '.cjs'}:
+            return DiagnosticsManager.check_javascript(file_name, content)
+        if ext in {'.ts', '.tsx'}:
+            return DiagnosticsManager.check_typescript(file_name, content, ext)
+        if ext in {'.md', '.txt', '.ini', '.cfg', '.env'}:
+            return {
+                'file': file_name,
+                'status': 'skipped',
+                'message': '純文字設定檔不進行語法偵錯。'
+            }
+
+        return {
+            'file': file_name,
+            'status': 'warning',
+            'message': '目前尚未提供此檔案類型的自動語法偵錯，請手動確認。'
+        }
+
+    @staticmethod
+    def check_python(file_name: str, content: str) -> Dict[str, Any]:
+        try:
+            ast.parse(content, filename=file_name)
+            return {
+                'file': file_name,
+                'status': 'passed',
+                'message': 'Python 語法檢查通過。'
+            }
+        except SyntaxError as exc:
+            location = f"第 {exc.lineno} 行"
+            if exc.offset:
+                location += f"第 {exc.offset} 字元"
+            detail = exc.msg
+            if exc.text:
+                detail += f"；程式碼片段：{exc.text.strip()}"
+            return {
+                'file': file_name,
+                'status': 'failed',
+                'message': f"{location}：{detail}"
+            }
+        except Exception as exc:
+            return {
+                'file': file_name,
+                'status': 'warning',
+                'message': f'無法檢查 Python 檔案：{exc}'
+            }
+
+    @staticmethod
+    def check_json(file_name: str, content: str) -> Dict[str, Any]:
+        try:
+            json.loads(content)
+            return {
+                'file': file_name,
+                'status': 'passed',
+                'message': 'JSON 結構有效。'
+            }
+        except json.JSONDecodeError as exc:
+            return {
+                'file': file_name,
+                'status': 'failed',
+                'message': f"第 {exc.lineno} 行第 {exc.colno} 列：{exc.msg}"
+            }
+
+    @staticmethod
+    def check_xml(file_name: str, content: str) -> Dict[str, Any]:
+        try:
+            ET.fromstring(content)
+            return {
+                'file': file_name,
+                'status': 'passed',
+                'message': 'XML 結構有效。'
+            }
+        except ET.ParseError as exc:
+            return {
+                'file': file_name,
+                'status': 'failed',
+                'message': f"XML 解析失敗：{exc}"
+            }
+
+    @staticmethod
+    def check_yaml(file_name: str, content: str) -> Dict[str, Any]:
+        try:
+            import yaml  # type: ignore
+        except ImportError:
+            return {
+                'file': file_name,
+                'status': 'skipped',
+                'message': '缺少 PyYAML 套件，請執行 pip install pyyaml 後再嘗試。'
+            }
+
+        try:
+            yaml.safe_load(content)
+            return {
+                'file': file_name,
+                'status': 'passed',
+                'message': 'YAML 結構有效。'
+            }
+        except yaml.YAMLError as exc:  # type: ignore
+            return {
+                'file': file_name,
+                'status': 'failed',
+                'message': f'YAML 解析失敗：{exc}'
+            }
+
+    @staticmethod
+    def check_javascript(file_name: str, content: str) -> Dict[str, Any]:
+        if not DiagnosticsManager.NODE_CMD:
+            return {
+                'file': file_name,
+                'status': 'skipped',
+                'message': '系統未安裝 Node.js，無法進行 JavaScript 語法偵錯。'
+            }
+
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile('w', suffix='.js', delete=False, encoding='utf-8') as tmp:
+                tmp.write(content)
+                tmp_path = tmp.name
+
+            process = subprocess.run(
+                [DiagnosticsManager.NODE_CMD, '--check', tmp_path],
+                capture_output=True,
+                text=True
+            )
+
+            if process.returncode == 0:
+                return {
+                    'file': file_name,
+                    'status': 'passed',
+                    'message': 'JavaScript 語法檢查通過。'
+                }
+
+            error_output = (process.stderr or process.stdout or '').strip()
+            message = error_output.splitlines()[0] if error_output else '未知錯誤'
+            return {
+                'file': file_name,
+                'status': 'failed',
+                'message': message
+            }
+        except Exception as exc:
+            return {
+                'file': file_name,
+                'status': 'warning',
+                'message': f'無法檢查 JavaScript 檔案：{exc}'
+            }
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    @staticmethod
+    def check_typescript(file_name: str, content: str, extension: str) -> Dict[str, Any]:
+        if not DiagnosticsManager.TSC_CMD:
+            return {
+                'file': file_name,
+                'status': 'skipped',
+                'message': '系統未安裝 TypeScript 編譯器(tsc)，無法進行語法偵錯。'
+            }
+
+        tmp_path = None
+        try:
+            suffix = '.tsx' if extension == '.tsx' else '.ts'
+            with tempfile.NamedTemporaryFile('w', suffix=suffix, delete=False, encoding='utf-8') as tmp:
+                tmp.write(content)
+                tmp_path = tmp.name
+
+            args = [DiagnosticsManager.TSC_CMD, '--pretty', 'false', '--noEmit', tmp_path]
+            if extension == '.tsx':
+                args.extend(['--jsx', 'react'])
+
+            process = subprocess.run(args, capture_output=True, text=True)
+
+            if process.returncode == 0:
+                return {
+                    'file': file_name,
+                    'status': 'passed',
+                    'message': 'TypeScript 語法檢查通過。'
+                }
+
+            error_output = (process.stderr or process.stdout or '').strip()
+            message = error_output.splitlines()[0] if error_output else '未知錯誤'
+            return {
+                'file': file_name,
+                'status': 'failed',
+                'message': message
+            }
+        except Exception as exc:
+            return {
+                'file': file_name,
+                'status': 'warning',
+                'message': f'無法檢查 TypeScript 檔案：{exc}'
+            }
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    @staticmethod
+    def build_prompt_block(entries: List[Dict[str, Any]]) -> str:
+        lines = []
+        symbol_map = {
+            'passed': '✅',
+            'failed': '❌',
+            'warning': '⚠️',
+            'skipped': 'ℹ️'
+        }
+
+        for entry in entries:
+            if not entry:
+                continue
+            status = entry.get('status', 'info')
+            symbol = symbol_map.get(status, 'ℹ️')
+            message = entry.get('message', '').strip()
+            file_label = entry.get('file', '未知檔案')
+            if len(message) > 200:
+                message = message[:200] + '…'
+            lines.append(f"{symbol} {file_label}：{message}")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def inject_prompt(prompt: str, diagnostics_block: str) -> str:
+        if not diagnostics_block:
+            return prompt
+
+        instruction = (
+            "【語法偵錯結果】\n"
+            f"{diagnostics_block}\n"
+            "請優先修正上述偵錯結果提及的問題，並在回覆中說明修正內容。"
+        )
+
+        if '【使用者請求】' in prompt:
+            return prompt.replace('【使用者請求】', f"{instruction}\n\n【使用者請求】", 1)
+
+        return f"{instruction}\n\n{prompt}"
 
 # ============================================
 # Gemini AI 模塊
@@ -1122,16 +1451,17 @@ class CodeProcessor:
     def parse_json_response(json_data: Dict) -> ProjectOutput:
         """解析 JSON 格式的 AI 回應"""
         try:
+            project_section = json_data.get('專案輸出', json_data)
             files = []
-            for file_data in json_data.get('files', []):
+            for file_data in project_section.get('files', []):
                 code = file_data.get('code', '')
-                
+
                 if isinstance(code, str):
                     code = code.replace('\\n', '\n')
                     code = code.replace('\\t', '\t')
                     code = code.replace('\\"', '"')
                     code = code.replace("\\'", "'")
-                
+
                 files.append(FileOutput(
                     filename=file_data.get('filename', 'untitled.txt'),
                     filetype=file_data.get('filetype', 'text'),
@@ -1147,16 +1477,16 @@ class CodeProcessor:
                     server_address=file_data.get('server_address'),
                     web_title=file_data.get('web_title')
                 ))
-            
+
             return ProjectOutput(
-                project_name=json_data.get('project_name', 'untitled_project'),
-                description=json_data.get('description', ''),
+                project_name=project_section.get('project_name', 'untitled_project'),
+                description=project_section.get('description', ''),
                 files=files,
-                main_file=json_data.get('main_file'),
-                setup_instructions=json_data.get('setup_instructions'),
-                run_instructions=json_data.get('run_instructions')
+                main_file=project_section.get('main_file'),
+                setup_instructions=project_section.get('setup_instructions'),
+                run_instructions=project_section.get('run_instructions')
             )
-        
+
         except Exception as e:
             logger.error(f"解析 JSON 回應失敗: {e}")
             raise
@@ -1660,20 +1990,25 @@ class ProcessManager:
         files: List[Dict] = None,
         is_iteration: bool = False,
         attach_screenshot: bool = False,
-        attach_terminal: bool = False
+        attach_terminal: bool = False,
+        user_visible_prompt: Optional[str] = None,
+        memory_context: Optional[str] = None,
+        include_diagnostics: bool = False
     ) -> ProcessResult:
         """執行完整的自動化流程 - 修復版"""
         
         result = ProcessResult(success=False, is_iteration=is_iteration)
         
         try:
+            files = list(files or [])
+            user_files_snapshot = list(files)
             if is_iteration:
                 logger.info("迭代模式:自動載入專案所有檔案")
                 project_files = ProjectManager.load_project_files(folder_path)
-                
+
                 if not files:
                     files = []
-                
+
                 files.extend(project_files)
                 logger.info(f"已附加 {len(project_files)} 個專案檔案")
             
@@ -1685,19 +2020,22 @@ class ProcessManager:
                     result.terminal_output = terminal_output
             
             # ⭐ 修復:在正確的時機保存用戶消息
+            display_prompt = user_visible_prompt or prompt
+
             ConversationManager.add_message(
                 folder_path,
                 'user',
-                prompt,
-                files=[{'name': f.get('name'), 'type': f.get('type')} for f in (files or [])],
-                terminal_output=terminal_output
+                display_prompt,
+                files=[{'name': f.get('name'), 'type': f.get('type')} for f in user_files_snapshot],
+                terminal_output=terminal_output,
+                metadata={'memory_context': memory_context} if memory_context else None
             )
             
             if is_iteration and attach_screenshot:
                 project_info = ProjectManager.load_project_info(folder_path)
                 if project_info:
                     logger.info("迭代模式:檢查是否有運行中的程序")
-                    
+
                     running_programs = ProgramManager.check_programs()
                     
                     if not running_programs or all(p['status'] != 'running' for p in running_programs):
@@ -1750,9 +2088,20 @@ class ProcessManager:
                     if not files:
                         files = []
                     files.extend(screenshot_files)
-                    
+
                     result.screenshots = [s['filename'] for s in screenshots]
-            
+
+            if include_diagnostics:
+                try:
+                    diagnostics_entries = DiagnosticsManager.generate(files)
+                    result.diagnostics = diagnostics_entries
+                    diagnostics_block = DiagnosticsManager.build_prompt_block(diagnostics_entries)
+                    if diagnostics_block:
+                        prompt = DiagnosticsManager.inject_prompt(prompt, diagnostics_block)
+                        logger.info("已將語法偵錯結果附加至提示詞")
+                except Exception as diag_error:
+                    logger.error(f"語法偵錯流程失敗: {diag_error}")
+
             logger.info("Step 1: 呼叫 Gemini AI...")
             if files:
                 logger.info(f"包含 {len(files)} 個檔案")
@@ -1763,14 +2112,34 @@ class ProcessManager:
                 prompt, config, files, terminal_output
             )
             result.ai_response = ai_response
-            result.ai_response_json = json_data
             result.usage_metadata = usage_metadata
-            
+
+            normalized_json = {}
+            if json_data:
+                if isinstance(json_data, list):
+                    normalized_json = json_data[0] if json_data else {}
+                else:
+                    normalized_json = json_data
+
+            if normalized_json:
+                memory_snapshot = normalized_json.get('核心記憶模塊') or normalized_json.get('core_memory_module')
+                evaluation_snapshot = {
+                    '評分': normalized_json.get('評分'),
+                    '內容評價': normalized_json.get('內容評價'),
+                    '扣分原因': normalized_json.get('扣分原因'),
+                    '改進建議': normalized_json.get('改進建議')
+                }
+                evaluation_snapshot = {k: v for k, v in evaluation_snapshot.items() if v is not None}
+                result.memory_snapshot = memory_snapshot
+                result.evaluation_snapshot = evaluation_snapshot
+
+            result.ai_response_json = normalized_json if normalized_json else None
+
             logger.info("Step 2: 解析 AI 回應...")
             try:
-                if json_data:
+                if normalized_json:
                     logger.info("使用 JSON 模式解析")
-                    project = CodeProcessor.parse_json_response(json_data)
+                    project = CodeProcessor.parse_json_response(normalized_json)
                 else:
                     logger.info("嘗試從文本中提取 JSON")
                     try:
@@ -1781,8 +2150,10 @@ class ProcessManager:
                             json_str = json_str.replace('\\n', '\n')
                             json_str = json_str.replace('\\t', '\t')
                             potential_json = json.loads(json_str)
+                            if isinstance(potential_json, list):
+                                potential_json = potential_json[0] if potential_json else {}
                             project = CodeProcessor.parse_json_response(potential_json)
-                            result.ai_response_json = potential_json
+                            result.ai_response_json = potential_json or None
                             logger.info("成功從文本中提取並解析 JSON")
                         else:
                             raise ValueError("無法從回應中找到有效的JSON結構")
@@ -1824,7 +2195,11 @@ class ProcessManager:
                     folder_path,
                     'assistant',
                     result.output,
-                    metadata={'error': True, 'error_type': 'parse_error'}
+                    metadata={
+                        'error': True,
+                        'error_type': 'parse_error',
+                        **({'diagnostics': result.diagnostics} if result.diagnostics else {})
+                    }
                 )
                 
                 return result
@@ -2055,12 +2430,22 @@ class ProcessManager:
                 result.output,
                 metadata={
                     'project_name': project.project_name,
-                    'files_count': len(project.files)
+                    'files_count': len(project.files),
+                    **({'memory_snapshot': result.memory_snapshot} if result.memory_snapshot else {}),
+                    **({'evaluation_snapshot': result.evaluation_snapshot} if result.evaluation_snapshot else {}),
+                    **({'diagnostics': result.diagnostics} if result.diagnostics else {})
                 },
                 terminal_output=result.terminal_output,
                 usage_metadata=usage_metadata  # ⭐ 直接傳遞 usage_metadata
             )
-            
+
+            if result.memory_snapshot or result.evaluation_snapshot:
+                ConversationManager.update_memory_state(
+                    final_project_dir,
+                    result.memory_snapshot,
+                    result.evaluation_snapshot
+                )
+
         except Exception as e:
             result.error = str(e)
             logger.error(f"處理流程失敗: {e}")
@@ -2075,7 +2460,11 @@ class ProcessManager:
                 folder_path,
                 'assistant',
                 f"執行失敗: {result.error}",
-                metadata={'error': True, 'error_type': 'execution_error'}
+                metadata={
+                    'error': True,
+                    'error_type': 'execution_error',
+                    **({'diagnostics': result.diagnostics} if result.diagnostics else {})
+                }
             )
         
         return result
@@ -2189,7 +2578,9 @@ def load_project():
             'conversation': {
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'memory_snapshot': conversation.memory_snapshot,
+                'evaluation_snapshot': conversation.evaluation_snapshot
             }
         })
         
@@ -2229,7 +2620,9 @@ def get_conversation(project_dir):
                 'project_name': conversation.project_name,
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'memory_snapshot': conversation.memory_snapshot,
+                'evaluation_snapshot': conversation.evaluation_snapshot
             }
         })
     except Exception as e:
@@ -2287,11 +2680,14 @@ def run_process():
         
         folder_path = data.get('folder_path')
         prompt = data.get('prompt')
+        display_prompt = data.get('display_prompt')
+        memory_context = data.get('memory_context')
         config_data = data.get('config', {})
         files = data.get('files', [])
         is_iteration = data.get('is_iteration', False)
         attach_screenshot = data.get('attach_screenshot', False)
         attach_terminal = data.get('attach_terminal', False)
+        include_diagnostics = data.get('include_diagnostics', False)
         
         if not all([folder_path, prompt]):
             return jsonify({
@@ -2309,7 +2705,10 @@ def run_process():
             files,
             is_iteration,
             attach_screenshot,
-            attach_terminal
+            attach_terminal,
+            user_visible_prompt=display_prompt,
+            memory_context=memory_context,
+            include_diagnostics=include_diagnostics
         )
         
         response_data = {
@@ -2324,7 +2723,10 @@ def run_process():
             'screenshots': result.screenshots,
             'is_iteration': result.is_iteration,
             'usage_metadata': result.usage_metadata,
-            'terminal_output': result.terminal_output
+            'terminal_output': result.terminal_output,
+            'memory_snapshot': result.memory_snapshot,
+            'evaluation_snapshot': result.evaluation_snapshot,
+            'diagnostics': result.diagnostics
         }
         
         if result.project_data:

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -13,6 +13,9 @@ let allProjects = [];
 let modelConfig = null;
 let sidebarCollapsed = false;
 let MODEL_LIMITS = {};
+let projectMemoryState = {};
+let autoAttachMemory = true;
+let attachDiagnostics = false;
 
 // ============================================
 // Loading Overlay 控制 - 修復版
@@ -48,6 +51,17 @@ window.addEventListener('DOMContentLoaded', () => {
     loadProjectsList();
     checkRunningPrograms();
     setInterval(checkRunningPrograms, 5000);
+
+    const memoryMenuItem = document.getElementById('memoryMenuItem');
+    if (memoryMenuItem) {
+        memoryMenuItem.classList.add('active');
+    }
+    const diagnosticsMenuItem = document.getElementById('diagnosticsMenuItem');
+    if (diagnosticsMenuItem && attachDiagnostics) {
+        diagnosticsMenuItem.classList.add('active');
+    }
+    updateMemoryMenuHint();
+    renderMemoryPanel();
     
     // 點擊外部關閉選單
     document.addEventListener('click', (e) => {
@@ -279,6 +293,248 @@ function toggleAttachTerminal() {
     togglePlusMenu();
 }
 
+function toggleAutoAttachMemory() {
+    autoAttachMemory = !autoAttachMemory;
+    const menuItem = document.getElementById('memoryMenuItem');
+    if (menuItem) {
+        if (autoAttachMemory) {
+            menuItem.classList.add('active');
+            showNotification('已啟用自動附加記憶上下文', 'success');
+        } else {
+            menuItem.classList.remove('active');
+            showNotification('已關閉自動附加記憶上下文', 'info');
+        }
+    }
+    togglePlusMenu();
+}
+
+function toggleSyntaxDiagnostics() {
+    attachDiagnostics = !attachDiagnostics;
+    const menuItem = document.getElementById('diagnosticsMenuItem');
+    if (menuItem) {
+        if (attachDiagnostics) {
+            menuItem.classList.add('active');
+            showNotification('已啟用語法偵錯報告', 'success');
+        } else {
+            menuItem.classList.remove('active');
+            showNotification('已關閉語法偵錯報告', 'info');
+        }
+    }
+    togglePlusMenu();
+}
+
+function getCurrentMemoryState() {
+    if (!currentProjectDir) return null;
+    return projectMemoryState[currentProjectDir] || null;
+}
+
+function setProjectMemoryState(projectDir, memorySnapshot = {}, evaluationSnapshot = {}) {
+    if (!projectDir) return;
+    projectMemoryState[projectDir] = {
+        memory: memorySnapshot || {},
+        evaluation: evaluationSnapshot || {}
+    };
+
+    if (projectDir === currentProjectDir) {
+        updateMemoryMenuHint();
+        renderMemoryPanel();
+    }
+}
+
+function updateMemoryMenuHint() {
+    const hint = document.getElementById('memorySuggestionPreview');
+    if (!hint) return;
+
+    if (!currentProjectDir) {
+        hint.textContent = '上一輪改進建議：尚未選擇專案';
+        hint.title = '';
+        return;
+    }
+
+    const state = getCurrentMemoryState();
+    const suggestion = state?.evaluation?.['改進建議'];
+
+    if (suggestion !== undefined && suggestion !== null && suggestion !== '') {
+        const trimmed = suggestion.length > 40 ? `${suggestion.slice(0, 40)}…` : suggestion;
+        hint.textContent = `上一輪改進建議：${trimmed}`;
+        hint.title = suggestion;
+    } else {
+        hint.textContent = '上一輪改進建議：尚未有資料';
+        hint.title = '';
+    }
+}
+
+function renderMemoryPanel() {
+    const panel = document.getElementById('memoryPanel');
+    const body = document.getElementById('memoryPanelBody');
+    const scoreEl = document.getElementById('memoryScoreDisplay');
+    const projectLabel = document.getElementById('memoryProjectLabel');
+    const evaluationList = document.getElementById('memoryEvaluationList');
+    const summaryBox = document.getElementById('memorySummaryBox');
+    const stmBox = document.getElementById('memorySTMBox');
+    const ltmBox = document.getElementById('memoryLTMBox');
+    const goalsList = document.getElementById('memoryGoalsList');
+
+    if (!panel || !body || !scoreEl || !projectLabel || !evaluationList || !summaryBox || !stmBox || !ltmBox || !goalsList) {
+        return;
+    }
+
+    if (!currentProjectDir) {
+        panel.style.display = 'none';
+        body.style.maxHeight = 'none';
+        return;
+    }
+
+    panel.style.display = 'flex';
+    body.style.maxHeight = 'none';
+    projectLabel.textContent = currentProject?.name || '未命名專案';
+
+    const state = getCurrentMemoryState();
+    const evaluation = state?.evaluation || {};
+    const memory = state?.memory || {};
+
+    const score = evaluation['評分'];
+    scoreEl.textContent = (score !== undefined && score !== null && score !== '') ? `${score} 分` : '--';
+
+    evaluationList.innerHTML = '';
+    const evaluationItems = [
+        { label: '內容評價', value: evaluation['內容評價'] },
+        { label: '扣分原因', value: evaluation['扣分原因'] },
+        { label: '改進建議', value: evaluation['改進建議'] }
+    ];
+
+    let hasEvaluationContent = false;
+    evaluationItems.forEach(item => {
+        const hasValue = item.value || item.value === '無';
+        if (hasValue) {
+            hasEvaluationContent = true;
+            const row = document.createElement('div');
+            row.className = 'memory-evaluation-item';
+            const labelEl = document.createElement('span');
+            labelEl.className = 'memory-eval-label';
+            labelEl.textContent = item.label;
+            const valueEl = document.createElement('span');
+            valueEl.className = 'memory-eval-value';
+            valueEl.textContent = item.value;
+            row.append(labelEl, valueEl);
+            evaluationList.appendChild(row);
+        }
+    });
+
+    if (!hasEvaluationContent) {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'memory-placeholder';
+        placeholder.textContent = '尚未產生評分資訊';
+        evaluationList.appendChild(placeholder);
+    }
+
+    summaryBox.textContent = memory['專案總結'] || '尚未建立專案總結';
+    renderMemoryList(stmBox, memory['短期記憶'], '尚未累積短期記憶');
+    renderMemoryList(ltmBox, memory['長期記憶'], '尚未建立長期記憶');
+
+    goalsList.innerHTML = '';
+    const goals = Array.isArray(memory['專案目標']) ? memory['專案目標'] : [];
+    if (goals.length === 0) {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'memory-placeholder';
+        placeholder.textContent = '尚未設定專案目標';
+        goalsList.appendChild(placeholder);
+    } else {
+        const statusClassWhitelist = new Set(['已完成', '進行中', '未開始']);
+
+        goals.forEach(goal => {
+            const item = document.createElement('div');
+            item.className = 'memory-goal-item';
+
+            const stepEl = document.createElement('div');
+            stepEl.className = 'goal-step';
+            const stepLabel = goal && Object.prototype.hasOwnProperty.call(goal, '步驟')
+                ? `步驟 ${goal['步驟']}`
+                : '步驟 ?';
+            const stepLabelEl = document.createElement('span');
+            stepLabelEl.textContent = stepLabel;
+            stepEl.appendChild(stepLabelEl);
+
+            if (goal && goal['是否為當前任務']) {
+                const badge = document.createElement('span');
+                badge.className = 'goal-current';
+                badge.textContent = '當前';
+                stepEl.appendChild(badge);
+            }
+
+            const taskEl = document.createElement('div');
+            taskEl.className = 'goal-task';
+            taskEl.textContent = goal && goal['任務'] ? goal['任務'] : '未提供任務描述';
+
+            const statusEl = document.createElement('div');
+            statusEl.className = 'goal-status';
+            const statusText = goal && goal['狀態'] ? goal['狀態'] : '未設定';
+            statusEl.textContent = statusText;
+            if (statusClassWhitelist.has(statusText)) {
+                statusEl.classList.add(statusText);
+            }
+
+            item.append(stepEl, taskEl, statusEl);
+            goalsList.appendChild(item);
+        });
+    }
+
+    updateMemoryMenuHint();
+}
+
+function toggleMemoryPanel() {
+    const panel = document.getElementById('memoryPanel');
+    const btn = document.getElementById('memoryCollapseBtn');
+
+    if (!panel || !btn) return;
+
+    const collapsed = panel.classList.toggle('collapsed');
+    btn.classList.toggle('collapsed', collapsed);
+    btn.setAttribute('aria-expanded', (!collapsed).toString());
+}
+
+function parseMemoryItems(rawValue) {
+    if (Array.isArray(rawValue)) {
+        return rawValue.map(item => (typeof item === 'string' ? item.trim() : '')).filter(Boolean);
+    }
+
+    if (!rawValue || typeof rawValue !== 'string') {
+        return [];
+    }
+
+    const normalized = rawValue.replace(/\r\n?/g, '\n').trim();
+    if (!normalized) return [];
+
+    let items = normalized.split(/\n+/).map(item => item.trim()).filter(Boolean);
+
+    if (items.length <= 1) {
+        items = normalized.split(/[、,;；]/).map(item => item.trim()).filter(Boolean);
+    }
+
+    return items.length > 0 ? items : [normalized];
+}
+
+function renderMemoryList(container, rawValue, emptyText) {
+    if (!container) return;
+
+    container.innerHTML = '';
+
+    const items = parseMemoryItems(rawValue);
+    if (items.length === 0) {
+        const placeholder = document.createElement('li');
+        placeholder.className = 'memory-placeholder';
+        placeholder.textContent = emptyText;
+        container.appendChild(placeholder);
+        return;
+    }
+
+    items.forEach(text => {
+        const li = document.createElement('li');
+        li.textContent = text;
+        container.appendChild(li);
+    });
+}
+
 function showAdvancedSettings() {
     togglePlusMenu();
     showSettingsModal();
@@ -314,9 +570,9 @@ function handleKeyDown(event) {
 // ============================================
 async function handleSubmit() {
     const input = document.getElementById('mainInput');
-    const prompt = input?.value.trim();
-    
-    if (!prompt) return;
+    const userPrompt = input?.value.trim();
+
+    if (!userPrompt) return;
 
     if (!currentProjectDir) {
         showNotification('請先選擇或創建專案', 'warning');
@@ -327,7 +583,65 @@ async function handleSubmit() {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
 
-    addMessage('user', prompt);
+    const attachmentsForMessage = uploadedFiles.map(file => ({
+        name: file.name,
+        type: file.type || 'text/plain'
+    }));
+
+    let requestPrompt = userPrompt;
+    let memoryContextBlock = null;
+
+    if (autoAttachMemory) {
+        const state = getCurrentMemoryState();
+        if (state) {
+            const memoryLines = [];
+            const memory = state.memory || {};
+            const evaluation = state.evaluation || {};
+
+            if (memory['專案總結']) {
+                memoryLines.push(`專案總結：${memory['專案總結']}`);
+            }
+            if (memory['短期記憶']) {
+                const stmItems = parseMemoryItems(memory['短期記憶']);
+                if (stmItems.length > 0) {
+                    memoryLines.push(`短期記憶：\n- ${stmItems.join('\n- ')}`);
+                } else {
+                    memoryLines.push(`短期記憶：${memory['短期記憶']}`);
+                }
+            }
+            if (memory['長期記憶']) {
+                const ltmItems = parseMemoryItems(memory['長期記憶']);
+                if (ltmItems.length > 0) {
+                    memoryLines.push(`長期記憶：\n- ${ltmItems.join('\n- ')}`);
+                } else {
+                    memoryLines.push(`長期記憶：${memory['長期記憶']}`);
+                }
+            }
+
+            const goals = Array.isArray(memory['專案目標']) ? memory['專案目標'] : [];
+            if (goals.length > 0) {
+                const goalLines = goals.map(goal => {
+                    const currentFlag = goal['是否為當前任務'] ? '【當前任務】' : '';
+                    return `步驟${goal['步驟']} ${goal['任務']} (${goal['狀態'] || '未設定'})${currentFlag}`;
+                });
+                memoryLines.push(`專案目標：\n${goalLines.join('\n')}`);
+            }
+
+            const improvement = evaluation['改進建議'];
+            if (improvement && improvement !== '無') {
+                memoryLines.push(`上一輪改進建議：${improvement}`);
+            }
+
+            if (memoryLines.length > 0) {
+                memoryContextBlock = `【長短期記憶摘要】\n${memoryLines.join('\n')}`;
+                requestPrompt = `${memoryContextBlock}\n\n【使用者請求】\n${userPrompt}`;
+            }
+        }
+    }
+
+    addMessage('user', userPrompt, null, null, attachmentsForMessage, {
+        memoryContext: memoryContextBlock
+    });
 
     input.value = '';
     updateSubmitButton();
@@ -343,20 +657,35 @@ async function handleSubmit() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 folder_path: currentProjectDir,
-                prompt: prompt,
+                prompt: requestPrompt,
+                display_prompt: userPrompt,
+                memory_context: memoryContextBlock,
                 config: config,
                 files: uploadedFiles,
                 is_iteration: isIterationMode,
                 attach_screenshot: isIterationMode && autoScreenshot,
-                attach_terminal: attachTerminal
+                attach_terminal: attachTerminal,
+                include_diagnostics: attachDiagnostics
             })
         });
 
         const result = await response.json();
 
         if (result.success) {
-            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output);
-            
+            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output, [], {
+                evaluation: result.evaluation_snapshot,
+                memory: result.memory_snapshot,
+                diagnostics: result.diagnostics || []
+            });
+
+            if (currentProjectDir) {
+                setProjectMemoryState(
+                    currentProjectDir,
+                    result.memory_snapshot || {},
+                    result.evaluation_snapshot || {}
+                );
+            }
+
             if (result.project) {
                 currentProject = result.project;
                 if (result.ai_response_json) {
@@ -386,7 +715,9 @@ async function handleSubmit() {
             updateFilesPreview();
             updateAttachedFilesDisplay();
         } else {
-            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`);
+            addMessage('assistant', `✕ 執行失敗：${result.error || result.output}`, null, null, [], {
+                diagnostics: result.diagnostics || []
+            });
             showNotification(`執行失敗：${result.error}`, 'error');
         }
     } catch (error) {
@@ -397,10 +728,10 @@ async function handleSubmit() {
     }
 }
 
-function addMessage(role, content, usageMetadata = null, terminalOutput = null) {
+function addMessage(role, content, usageMetadata = null, terminalOutput = null, attachments = [], metadata = {}) {
     const container = document.getElementById('resultsContainer');
     if (!container) return;
-    
+
     const message = document.createElement('div');
     message.className = `result-message ${role} selectable`;
 
@@ -424,20 +755,112 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
 
     message.appendChild(header);
     message.appendChild(messageContent);
-    
-    // ✅ Terminal輸出只顯示在用戶消息中
-    if (role === 'user' && terminalOutput && terminalOutput.trim()) {
+
+    if (attachments && attachments.length > 0) {
+        const attachmentsSection = document.createElement('div');
+        attachmentsSection.className = 'message-attachments';
+
+        attachments.forEach(file => {
+            if (!file || !file.name) return;
+            const chip = document.createElement('div');
+            chip.className = 'attachment-chip';
+
+            const iconEl = document.createElement('span');
+            iconEl.className = 'attachment-icon';
+            iconEl.textContent = '📎';
+
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'attachment-name';
+            nameSpan.textContent = file.name;
+            nameSpan.title = file.name;
+
+            const typeSpan = document.createElement('span');
+            typeSpan.className = 'attachment-type';
+            const typeLabelRaw = (file.type || '檔案').split('/')[0];
+            const typeLabel = typeLabelRaw ? typeLabelRaw.toUpperCase() : '檔案';
+            typeSpan.textContent = typeLabel;
+
+            chip.append(iconEl, nameSpan, typeSpan);
+            attachmentsSection.appendChild(chip);
+        });
+
+        message.appendChild(attachmentsSection);
+    }
+
+    if (metadata && metadata.memoryContext) {
+        const contextDetails = document.createElement('details');
+        contextDetails.className = 'memory-context-details';
+
+        const summaryEl = document.createElement('summary');
+        summaryEl.textContent = '已附加記憶上下文';
+
+        const contextText = document.createElement('pre');
+        contextText.className = 'memory-context-text selectable';
+        contextText.textContent = metadata.memoryContext;
+
+        contextDetails.append(summaryEl, contextText);
+        message.appendChild(contextDetails);
+    }
+
+    if (metadata && metadata.evaluation) {
+        const evalData = metadata.evaluation;
+        const hasScore = Object.prototype.hasOwnProperty.call(evalData, '評分');
+        const hasSuggestion = Object.prototype.hasOwnProperty.call(evalData, '改進建議');
+
+        if (hasScore || hasSuggestion) {
+            const scoreText = hasScore && evalData['評分'] !== null && evalData['評分'] !== undefined
+                ? `${evalData['評分']} 分`
+                : '未提供';
+            const suggestionRaw = hasSuggestion ? evalData['改進建議'] : undefined;
+            const suggestionText = suggestionRaw === undefined || suggestionRaw === '' ? '暫無' : suggestionRaw;
+
+            const evaluationBox = document.createElement('div');
+            evaluationBox.className = 'message-evaluation-box';
+
+            const scoreRow = document.createElement('div');
+            scoreRow.className = 'evaluation-row';
+            const scoreLabel = document.createElement('span');
+            scoreLabel.className = 'evaluation-label';
+            scoreLabel.textContent = '評分';
+            const scoreValueEl = document.createElement('span');
+            scoreValueEl.className = 'evaluation-value';
+            scoreValueEl.textContent = scoreText;
+            scoreRow.append(scoreLabel, scoreValueEl);
+
+            const suggestionRow = document.createElement('div');
+            suggestionRow.className = 'evaluation-row';
+            const suggestionLabel = document.createElement('span');
+            suggestionLabel.className = 'evaluation-label';
+            suggestionLabel.textContent = '改進建議';
+            const suggestionValue = document.createElement('span');
+            suggestionValue.className = 'evaluation-value';
+            suggestionValue.textContent = suggestionText;
+            suggestionRow.append(suggestionLabel, suggestionValue);
+
+            evaluationBox.append(scoreRow, suggestionRow);
+            message.appendChild(evaluationBox);
+        }
+    }
+
+    if (terminalOutput && terminalOutput.trim()) {
         const terminalSection = document.createElement('div');
         terminalSection.className = 'terminal-output-section';
-        terminalSection.innerHTML = `
-            <div class="terminal-header">
-                <span class="terminal-title">Terminal 輸出</span>
-            </div>
-            <div class="terminal-body selectable">${terminalOutput}</div>
-        `;
+
+        const terminalHeader = document.createElement('div');
+        terminalHeader.className = 'terminal-header';
+        const terminalTitle = document.createElement('span');
+        terminalTitle.className = 'terminal-title';
+        terminalTitle.textContent = 'Terminal 輸出';
+        terminalHeader.appendChild(terminalTitle);
+
+        const terminalBody = document.createElement('div');
+        terminalBody.className = 'terminal-body selectable';
+        terminalBody.textContent = terminalOutput;
+
+        terminalSection.append(terminalHeader, terminalBody);
         message.appendChild(terminalSection);
     }
-    
+
     // Token使用統計只顯示在AI回應中
     if (role === 'assistant' && usageMetadata && typeof usageMetadata === 'object') {
         const tokenUsage = document.createElement('div');
@@ -490,7 +913,9 @@ async function createNewProject() {
         if (result.success && result.path) {
             currentProjectDir = result.path;
             isIterationMode = false;
-            
+
+            setProjectMemoryState(currentProjectDir, {}, {});
+
             document.getElementById('currentProjectDisplay').style.display = 'block';
             document.getElementById('currentProjectName').textContent = '新專案';
             const badge = document.getElementById('projectModeBadge');
@@ -654,7 +1079,10 @@ function getTimeAgo(dateString) {
 async function selectProject(project) {
     currentProjectDir = project.path;
     isIterationMode = true;
-    
+
+    renderMemoryPanel();
+    updateMemoryMenuHint();
+
     document.getElementById('currentProjectDisplay').style.display = 'block';
     document.getElementById('currentProjectName').textContent = project.name;
     const badge = document.getElementById('projectModeBadge');
@@ -717,11 +1145,43 @@ async function loadExistingProject(projectDir) {
                     container.innerHTML = '';
                     
                     for (const msg of result.conversation.messages) {
-                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output);
+                        const rawMetadata = msg.metadata || {};
+                        const normalizedMetadata = {
+                            ...rawMetadata
+                        };
+
+                        if (rawMetadata.evaluation_snapshot && !normalizedMetadata.evaluation) {
+                            normalizedMetadata.evaluation = rawMetadata.evaluation_snapshot;
+                        }
+                        if (rawMetadata.memory_snapshot && !normalizedMetadata.memory) {
+                            normalizedMetadata.memory = rawMetadata.memory_snapshot;
+                        }
+                        if (rawMetadata.memory_context && !normalizedMetadata.memoryContext) {
+                            normalizedMetadata.memoryContext = rawMetadata.memory_context;
+                        }
+
+                        addMessage(
+                            msg.role,
+                            msg.content,
+                            msg.usage_metadata,
+                            msg.terminal_output,
+                            msg.files || [],
+                            normalizedMetadata
+                        );
                     }
                 }
             }
-            
+
+            if (result.conversation) {
+                setProjectMemoryState(
+                    projectDir,
+                    result.conversation.memory_snapshot || {},
+                    result.conversation.evaluation_snapshot || {}
+                );
+            } else {
+                setProjectMemoryState(projectDir, {}, {});
+            }
+
             return true;
         } else {
             return false;
@@ -831,14 +1291,16 @@ function resetToHome() {
     document.getElementById('resultsContainer').innerHTML = '';
     document.getElementById('projectStructureSection').style.display = 'none';
     document.getElementById('homeBtn').style.display = 'none';
-    
+
     document.querySelectorAll('.project-item').forEach(item => {
         item.classList.remove('active');
     });
-    
+
     updateFilesPreview();
     updateAttachedFilesDisplay();
-    
+    renderMemoryPanel();
+    updateMemoryMenuHint();
+
     showNotification('已回到初始介面', 'info');
 }
 

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -25,6 +25,10 @@
     --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
     --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
+    --success-color: #15803d;
+    --warning-color: #b45309;
+    --error-color: #dc2626;
+    --info-color: #2563eb;
 }
 
 body {
@@ -760,6 +764,13 @@ body {
     background: var(--bg-secondary);
 }
 
+.menu-hint {
+    font-size: 12px;
+    color: var(--text-secondary);
+    padding: 4px 6px 8px 6px;
+    line-height: 1.4;
+}
+
 .menu-divider {
     height: 1px;
     background: var(--border-light);
@@ -811,13 +822,282 @@ body {
 }
 
 /* =================================== */
-/* 結果容器 */
+/* 對話與記憶佈局 */
 /* =================================== */
-.results-container {
-    max-width: 900px;
+.conversation-layout {
+    display: flex;
+    gap: 20px;
     width: 100%;
-    margin: 0 auto;
+    align-items: flex-start;
+}
+
+.results-container {
+    flex: 1;
+    max-width: 820px;
+    width: 100%;
+    margin: 0;
     padding: 20px;
+}
+
+
+.memory-panel {
+    width: 320px;
+    min-width: 280px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    border-radius: 12px;
+    box-shadow: var(--shadow-sm);
+    display: flex;
+    flex-direction: column;
+    position: sticky;
+    top: 90px;
+    max-height: calc(100vh - 140px);
+    overflow: hidden;
+    flex-shrink: 0;
+    transition: box-shadow 0.2s ease, border-color 0.2s ease, width 0.3s ease;
+}
+
+.memory-panel.collapsed {
+    width: 56px;
+    min-width: 56px;
+    border-color: var(--border-light);
+    overflow: visible;
+}
+
+.memory-panel.collapsed::after {
+    content: '記憶面板';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    writing-mode: vertical-rl;
+    font-size: 12px;
+    letter-spacing: 0.2em;
+    color: var(--text-secondary);
+    pointer-events: none;
+}
+
+.memory-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+    border-bottom: 1px solid var(--border-light);
+    background: var(--bg-primary);
+    gap: 12px;
+}
+
+.memory-panel.collapsed .memory-panel-header {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 6px;
+    gap: 12px;
+}
+
+.memory-title-group h3 {
+    font-size: 16px;
+    margin-bottom: 4px;
+}
+
+.memory-panel.collapsed .memory-title-group {
+    display: none;
+}
+
+.memory-project-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.memory-panel.collapsed .memory-header-actions {
+    flex-direction: column;
+    gap: 6px;
+}
+
+.memory-score {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.memory-panel.collapsed .memory-score {
+    display: none;
+}
+
+.memory-collapse-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    background: var(--bg-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.memory-collapse-btn:hover {
+    background: var(--bg-secondary);
+}
+
+.memory-collapse-btn.collapsed svg {
+    transform: rotate(180deg);
+}
+
+.memory-panel.collapsed .memory-panel-body {
+    display: none;
+}
+
+.memory-panel-body {
+    padding: 16px 20px 20px 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    transition: max-height 0.3s ease, padding 0.3s ease;
+}
+
+.memory-section h4 {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+    letter-spacing: 0.4px;
+}
+
+.memory-text {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+}
+
+.memory-evaluation-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.memory-evaluation-item {
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-light);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.memory-eval-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-eval-value {
+    font-size: 13px;
+    color: var(--text-primary);
+    line-height: 1.5;
+    white-space: pre-wrap;
+}
+
+.memory-list {
+    list-style: disc;
+    margin: 8px 0 0;
+    padding-left: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--text-primary);
+    line-height: 1.5;
+}
+
+.memory-list .memory-placeholder {
+    list-style: none;
+    padding-left: 0;
+}
+
+.memory-placeholder {
+    font-size: 12px;
+    color: var(--text-tertiary);
+    padding: 10px 0;
+}
+
+.memory-goals-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.memory-goal-item {
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: var(--bg-secondary);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.goal-step {
+    font-size: 12px;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.goal-current {
+    font-size: 10px;
+    color: #fff;
+    background: var(--primary-color);
+    border-radius: 999px;
+    padding: 2px 6px;
+}
+
+.goal-task {
+    font-size: 13px;
+    color: var(--text-primary);
+}
+
+.goal-status {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.goal-status.已完成 {
+    color: #16a34a;
+}
+
+.goal-status.進行中 {
+    color: #d97706;
+}
+
+.goal-status.未開始 {
+    color: #64748b;
+}
+
+@media (max-width: 1200px) {
+    .conversation-layout {
+        flex-direction: column;
+    }
+
+    .memory-panel {
+        position: static;
+        max-height: none;
+    }
+
+    .memory-panel:not(.collapsed) {
+        width: 100%;
+        min-width: auto;
+    }
 }
 
 .result-message {
@@ -862,6 +1142,158 @@ body {
     color: var(--text-primary);
     white-space: pre-wrap;
     word-wrap: break-word;
+}
+
+.message-attachments {
+    margin-top: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.attachment-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.attachment-icon {
+    font-size: 14px;
+}
+
+.attachment-name {
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+}
+
+.attachment-type {
+    font-size: 10px;
+    color: var(--text-tertiary);
+}
+
+.memory-context-details {
+    margin-top: 10px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    padding: 8px 12px;
+    font-size: 13px;
+}
+
+.memory-context-details summary {
+    cursor: pointer;
+    color: var(--primary-color);
+    font-weight: 600;
+}
+
+.memory-context-details[open] summary {
+    margin-bottom: 6px;
+}
+
+.memory-context-text {
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+}
+
+.message-evaluation-box {
+    margin-top: 10px;
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: var(--bg-primary);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.diagnostics-details {
+    margin-top: 10px;
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: var(--bg-primary);
+    font-size: 13px;
+}
+
+.diagnostics-details summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--primary-color);
+}
+
+.diagnostics-details[open] summary {
+    margin-bottom: 8px;
+}
+
+.diagnostic-entry {
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 8px 10px;
+    background: var(--bg-secondary);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 8px;
+}
+
+.diagnostic-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    font-weight: 500;
+}
+
+.diagnostic-file {
+    font-size: 13px;
+    color: var(--text-primary);
+}
+
+.diagnostic-status {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.diagnostic-status.passed { color: var(--success-color); }
+.diagnostic-status.failed { color: var(--error-color); }
+.diagnostic-status.warning { color: var(--warning-color); }
+.diagnostic-status.skipped { color: var(--text-tertiary); }
+.diagnostic-status.info { color: var(--info-color); }
+
+.diagnostic-message {
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    white-space: pre-wrap;
+}
+
+.evaluation-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 12px;
+}
+
+.evaluation-label {
+    color: var(--text-secondary);
+}
+
+.evaluation-value {
+    color: var(--text-primary);
+    font-weight: 600;
+    text-align: right;
 }
 
 .token-usage {

--- a/vscode_controller_project3-1/templates/index.html
+++ b/vscode_controller_project3-1/templates/index.html
@@ -179,7 +179,51 @@
                 </div>
             </div>
 
-            <div class="results-container" id="resultsContainer" style="display: none;"></div>
+            <div class="conversation-layout" id="conversationLayout">
+                <div class="results-container" id="resultsContainer" style="display: none;"></div>
+                <div class="memory-panel" id="memoryPanel" style="display: none;">
+                    <div class="memory-panel-header">
+                        <div class="memory-title-group">
+                            <h3>記憶與評分</h3>
+                            <span class="memory-project-label" id="memoryProjectLabel">尚未選擇專案</span>
+                        </div>
+                        <div class="memory-header-actions">
+                            <span class="memory-score" id="memoryScoreDisplay">--</span>
+                            <button class="memory-collapse-btn" id="memoryCollapseBtn" onclick="toggleMemoryPanel()" aria-label="切換記憶面板" aria-expanded="true">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <polyline points="9 6 15 12 9 18"/>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="memory-panel-body" id="memoryPanelBody">
+                        <section class="memory-section">
+                            <h4>品質評分</h4>
+                            <div class="memory-evaluation-list" id="memoryEvaluationList"></div>
+                        </section>
+                        <section class="memory-section">
+                            <h4>專案摘要</h4>
+                            <p class="memory-text" id="memorySummaryBox">尚未建立專案總結</p>
+                        </section>
+                        <section class="memory-section">
+                            <h4>短期記憶</h4>
+                            <ul class="memory-list" id="memorySTMBox">
+                                <li class="memory-placeholder">尚未累積短期記憶</li>
+                            </ul>
+                        </section>
+                        <section class="memory-section">
+                            <h4>長期記憶</h4>
+                            <ul class="memory-list" id="memoryLTMBox">
+                                <li class="memory-placeholder">尚未建立長期記憶</li>
+                            </ul>
+                        </section>
+                        <section class="memory-section">
+                            <h4>專案目標</h4>
+                            <div class="memory-goals-list" id="memoryGoalsList"></div>
+                        </section>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="input-area">
@@ -216,6 +260,22 @@
                                     <line x1="12" y1="19" x2="20" y2="19"/>
                                 </svg>
                                 <span>附加 Terminal 輸出</span>
+                            </div>
+                            <div class="menu-item" id="memoryMenuItem" onclick="toggleAutoAttachMemory()">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 20l9-5-9-5-9 5 9 5z"/>
+                                    <path d="M3 10l9-5 9 5"/>
+                                </svg>
+                                <span>自動附加記憶上下文</span>
+                            </div>
+                            <div class="menu-hint" id="memorySuggestionPreview">上一輪改進建議：尚未有資料</div>
+                            <div class="menu-item" id="diagnosticsMenuItem" onclick="toggleSyntaxDiagnostics()">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <rect x="3" y="4" width="14" height="16" rx="2"/>
+                                    <path d="M9 2h6v4"/>
+                                    <path d="M8 13l2.5 2.5L14 12"/>
+                                </svg>
+                                <span>語法偵錯報告</span>
                             </div>
                             <div class="menu-divider"></div>
                             <div class="menu-item" onclick="showAdvancedSettings()">


### PR DESCRIPTION
## Summary
- add a DiagnosticsManager that performs multi-language syntax checks, threads results into prompt construction, and returns diagnostics metadata
- extend the UI with a diagnostics toggle, bullet-style memory lists, and a sideways-collapsing memory panel to avoid overlapping controls
- update system instructions to emphasize list formatting for memories and prioritizing diagnostics feedback when available

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e8f567dfd08329a0150db63f7ffcdf