### PR TITLE
Add syntax diagnostics toggle and sideways memory panel

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -14,6 +14,7 @@ import threading
 import time
 import re
 import json
+import shutil
 import platform
 import logging
 import queue
@@ -194,6 +195,8 @@ class ProjectConversation:
     messages: List[ConversationMessage] = field(default_factory=list)
     created_at: str = ""
     updated_at: str = ""
+    memory_snapshot: Dict[str, Any] = field(default_factory=dict)
+    evaluation_snapshot: Dict[str, Any] = field(default_factory=dict)
 
 @dataclass
 class ProcessResult:
@@ -211,6 +214,9 @@ class ProcessResult:
     is_iteration: bool = False
     usage_metadata: Optional[Dict] = None
     terminal_output: str = ""
+    memory_snapshot: Optional[Dict[str, Any]] = None
+    evaluation_snapshot: Optional[Dict[str, Any]] = None
+    diagnostics_report: List[Dict[str, Any]] = field(default_factory=list)
 
 # ============================================
 # JSON Schema 定義 - 繁體中文化
@@ -221,141 +227,144 @@ def get_json_schema():
     return {
         "type": "object",
         "properties": {
-            "project_name": {"type": "string", "description": "專案名稱"},
-            "description": {"type": "string", "description": "專案描述"},
-            "main_file": {"type": "string", "description": "主要執行檔案"},
-            "setup_instructions": {"type": "array", "items": {"type": "string"}, "description": "設置指令"},
-            "run_instructions": {"type": "array", "items": {"type": "string"}, "description": "執行指令"},
-            "files": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "filename": {"type": "string", "description": "檔案名稱(含副檔名)"},
-                        "filetype": {
-                            "type": "string",
-                            "enum": ["python", "javascript", "html", "css", "typescript", "java", "cpp", "c", "go", "rust", "ruby", "php", "swift", "kotlin", "sql", "shell", "yaml", "json", "xml", "markdown", "text"],
-                            "description": "檔案類型"
-                        },
-                        "code": {"type": "string", "description": "完整程式碼內容"},
-                        "opens_window": {"type": "boolean", "description": "是否會開啟視窗"},
-                        "window_title": {"type": ["string", "null"], "description": "視窗標題(如果有)"},
-                        "install_requirements": {"type": "array", "items": {"type": "string"}, "description": "安裝需求(如 pip install package)"},
-                        "dependencies": {"type": "array", "items": {"type": "string"}, "description": "相依套件"},
-                        "description": {"type": "string", "description": "檔案描述"},
-                        "run_command": {"type": ["string", "null"], "description": "執行命令"},
-                        "is_web_app": {"type": "boolean", "description": "是否為網頁應用"},
-                        "can_open_standalone": {"type": "boolean", "description": "主程式是否能自動開啟獨立瀏覽器視窗"},
-                        "server_address": {"type": ["string", "null"], "description": "伺服器地址(如 http://localhost:5000)"},
-                        "web_title": {"type": ["string", "null"], "description": "網頁標題"}
+            "評分": {"type": "integer", "minimum": 0, "maximum": 100, "description": "請針對本次回應品質給出 0-100 分的整數評分"},
+            "內容評價": {"type": "string", "description": "200 字以內的簡短評論,需涵蓋規則遵守與內容品質"},
+            "扣分原因": {"type": "string", "description": "若評分未滿分,需具體指出扣分原因,否則填寫『無』"},
+            "改進建議": {"type": "string", "description": "列出下次回覆可改進之處,若無則填寫『無』"},
+            "核心記憶模塊": {
+                "type": "object",
+                "description": "保存長短期記憶與專案目標的模塊",
+                "properties": {
+                    "專案總結": {"type": "string", "description": "概述目前專案或對話重點"},
+                    "短期記憶": {
+                        "type": "array",
+                        "description": "以條列方式呈現最近幾輪對話的關鍵資訊",
+                        "items": {"type": "string"}
                     },
-                    "required": ["filename", "filetype", "code", "opens_window"]
-                }
+                    "長期記憶": {
+                        "type": "array",
+                        "description": "以條列方式描述專案長期背景、核心目標或重要限制",
+                        "items": {"type": "string"}
+                    },
+                    "專案目標": {
+                        "type": "array",
+                        "description": "依序列出至少四個專案目標與狀態",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "步驟": {"type": "integer", "description": "目標步驟編號"},
+                                "任務": {"type": "string", "description": "具體任務描述"},
+                                "狀態": {"type": "string", "enum": ["未開始", "進行中", "已完成"], "description": "任務狀態"},
+                                "是否為當前任務": {"type": "boolean", "description": "此任務是否為目前主要工作"}
+                            },
+                            "required": ["步驟", "任務", "狀態", "是否為當前任務"]
+                        },
+                        "minItems": 4
+                    }
+                },
+                "required": ["專案總結", "短期記憶", "長期記憶", "專案目標"]
+            },
+            "專案輸出": {
+                "type": "object",
+                "description": "包含完整程式碼與操作資訊的區塊",
+                "properties": {
+                    "project_name": {"type": "string", "description": "專案名稱"},
+                    "description": {"type": "string", "description": "專案描述"},
+                    "main_file": {"type": "string", "description": "主要執行檔案"},
+                    "setup_instructions": {"type": "array", "items": {"type": "string"}, "description": "設置指令"},
+                    "run_instructions": {"type": "array", "items": {"type": "string"}, "description": "執行指令"},
+                    "files": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "filename": {"type": "string", "description": "檔案名稱(含副檔名)"},
+                                "filetype": {
+                                    "type": "string",
+                                    "enum": ["python", "javascript", "html", "css", "typescript", "java", "cpp", "c", "go", "rust", "ruby", "php", "swift", "kotlin", "sql", "shell", "yaml", "json", "xml", "markdown", "text"],
+                                    "description": "檔案類型"
+                                },
+                                "code": {"type": "string", "description": "完整程式碼內容"},
+                                "opens_window": {"type": "boolean", "description": "是否會開啟視窗"},
+                                "window_title": {"type": ["string", "null"], "description": "視窗標題(如果有)"},
+                                "install_requirements": {"type": "array", "items": {"type": "string"}, "description": "安裝需求(如 pip install package)"},
+                                "dependencies": {"type": "array", "items": {"type": "string"}, "description": "相依套件"},
+                                "description": {"type": "string", "description": "檔案描述"},
+                                "run_command": {"type": ["string", "null"], "description": "執行命令"},
+                                "is_web_app": {"type": "boolean", "description": "是否為網頁應用"},
+                                "can_open_standalone": {"type": "boolean", "description": "主程式是否能自動開啟獨立瀏覽器視窗"},
+                                "server_address": {"type": ["string", "null"], "description": "伺服器地址(如 http://localhost:5000)"},
+                                "web_title": {"type": ["string", "null"], "description": "網頁標題"}
+                            },
+                            "required": ["filename", "filetype", "code", "opens_window"]
+                        }
+                    }
+                },
+                "required": ["project_name", "description", "files"]
             }
         },
-        "required": ["project_name", "description", "files"]
+        "required": ["評分", "內容評價", "扣分原因", "改進建議", "核心記憶模塊", "專案輸出"]
     }
 
 def get_json_system_instruction():
     """獲取 JSON 模式的系統指令 - 繁體中文版 + Flask修復"""
-    return """你是一位專業的程式碼助手,能夠生成完整、可運行的專案程式碼。
+    return """你是一位專業的程式碼與專案助理,負責在每次回應中同時提供程式碼成果、評分與記憶管理資訊,並優先根據最新的語法偵錯結果修復問題。
 
-回應時,你必須輸出一個符合以下結構的有效 JSON 物件:
+請務必輸出**單一 JSON 物件**,欄位結構如下:
 {
-    "project_name": "描述性的專案名稱",
-    "description": "專案功能的簡要描述",
-    "main_file": "main.py",
-    "setup_instructions": ["pip install package1", "pip install package2"],
-    "run_instructions": ["python main.py", "開啟瀏覽器前往 http://localhost:5000"],
-    "files": [
-        {
-            "filename": "main.py",
-            "filetype": "python",
-            "code": "import flask\\n\\napp = flask.Flask(__name__)\\n\\n@app.route('/')\\ndef home():\\n    return 'Hello World'\\n\\nif __name__ == '__main__':\\n    app.run(host='0.0.0.0', port=5000)",
-            "opens_window": false,
-            "window_title": null,
-            "install_requirements": ["pip install flask"],
-            "dependencies": ["flask"],
-            "description": "主應用程式檔案",
-            "run_command": "python main.py",
-            "is_web_app": true,
-            "can_open_standalone": false,
-            "server_address": "http://localhost:5000",
-            "web_title": "我的網頁應用"
-        }
-    ]
+  "評分": 0-100 的整數,
+  "內容評價": "200 字內的綜合評論",
+  "扣分原因": "若無扣分請填『無』",
+  "改進建議": "下一次回應可改進的方向,若無請填『無』",
+  "核心記憶模塊": {
+      "專案總結": "摘要最新對話或專案重點",
+      "短期記憶": ["依照條列方式列出最近幾輪對話的關鍵資訊"...],
+      "長期記憶": ["以條列方式描述專案背景、核心目標或重要限制"...],
+      "專案目標": [
+          {"步驟": 1, "任務": "...", "狀態": "已完成/進行中/未開始", "是否為當前任務": true/false},
+          {"步驟": 2, ... 至少四個項目}
+      ]
+  },
+  "專案輸出": {
+      "project_name": "專案名稱",
+      "description": "簡要描述",
+      "main_file": "主要程式檔案名稱",
+      "setup_instructions": ["pip install package1"...],
+      "run_instructions": ["python main.py"...],
+      "files": [
+          {
+              "filename": "檔案名稱(含副檔名)",
+              "filetype": "python/javascript/...",
+              "code": "完整無省略程式碼,使用實際換行符號",
+              "opens_window": true/false,
+              "window_title": null 或字串,
+              "install_requirements": ["pip install ..."],
+              "dependencies": ["flask", "numpy"...],
+              "description": "檔案用途說明",
+              "run_command": "python main.py" 或 null,
+              "is_web_app": true/false,
+              "can_open_standalone": true/false,
+              "server_address": "http://localhost:5000" 或 null,
+              "web_title": "網頁標題" 或 null
+          }
+      ]
+  }
 }
 
-重要格式要則:
-1. "code" 欄位必須包含正確格式化的程式碼,使用真實的換行符號和縮排
-2. 在 code 字串中使用實際的換行字元 (\\n) 和 Tab 字元 (\\t),不是文字上的 \\n 字串
-3. 程式碼必須是有效的 JSON 字串 - 正確跳脫引號
-4. 確保程式碼中的縮排正確保留
-5. 程式碼的每一行應該在 JSON 字串中獨立成行
+執行規範:
+1. 僅能輸出有效 JSON,不得加入多餘文字、註解或 Markdown。
+2. 若提供語法偵錯結果,請優先修正其中列出的錯誤或警告,並在回應中說明修正方式。
+3. "短期記憶" 與 "長期記憶" 必須為字串陣列,每個元素對應一項條列內容,不得回傳空字串;若沒有資料請輸出空陣列 []。
+4. "files" 內的程式碼必須為完整、可執行、無省略號的繁體中文註解或文字,並以真實 \n 代表換行、\t 代表縮排。
+5. 若為 Flask/Node 等伺服器程式,禁止使用 debug=True 或熱重載模式,Flask 必須採用 `app.run(host='0.0.0.0', port=5000)`。
+6. 所有網頁相關檔案需填寫 `is_web_app`, 並在必要時提供 `server_address` 與 `web_title`。
+7. 任何需要額外套件的檔案,必須在 `install_requirements` 中完整列出安裝指令。
+8. 多檔案專案需確保相依檔案之間的匯入路徑正確,不得遺漏必要資源。
+9. 所有字串請使用繁體中文說明,除非程式語言語法或函式庫名稱要求英文。
+10. 專案目標需依進度更新狀態,並清楚標示當前主要任務。
+11. 評分、扣分原因、改進建議需與本次回覆內容一致,不得空泛。
 
-**CRITICAL Flask/Web Server 要則:**
-1. **絕對禁止使用 debug=True** - 這會導致在 subprocess 中運行時崩潰
-2. Flask 應用必須使用:`app.run(host='0.0.0.0', port=5000)` (不帶 debug 參數)
-3. Node.js/Express 應用也不要使用開發模式的熱重載
-4. 如果需要開發便利性,可以在代碼註釋中說明手動運行時可加 debug=True
-
-網頁應用要則:
-1. 對於 HTML 檔案或伺服器應用程式(Flask、Node.js 等),設定 "is_web_app": true
-2. 只有在你的程式碼包含自動開啟瀏覽器功能時,才設定 "can_open_standalone": true:
-   - Python: 使用 webbrowser.open() 或 Flask 加上 app.run(port=5000) + webbrowser
-   - Node.js: 使用 'open' 套件或類似工具
-   - HTML: 如果是可以直接開啟的獨立 HTML
-3. 如果 "can_open_standalone" 為 false 但 "is_web_app" 為 true,請提供:
-   - "server_address": 應用程式將運行的 URL(例如:"http://localhost:5000")
-   - "web_title": 網頁的標題
-4. 對於獨立的 HTML 檔案,將 opens_window 和 is_web_app 都設為 true
-5. 對於伺服器應用程式,控制器將處理開啟獨立瀏覽器視窗
-
-重要要則:
-1. 始終生成完整、可運行的程式碼 - 不要使用佔位符或省略號
-2. 對於 GUI 應用程式(pygame/tkinter),設定視窗標題以匹配專案名稱
-3. 對於網頁應用,確保 HTML 有適當的 <title> 標籤
-4. 包含所有必要的匯入和錯誤處理
-5. 正確指定檔案類型(python、javascript、html 等)
-6. 對於 GUI 應用程式或獨立 HTML 檔案,將 opens_window 設為 true
-7. 在 install_requirements 中列出所有套件安裝命令
-8. 為每個檔案提供清晰的描述
-9. 對於多檔案專案,確保檔案正確連結
-
-支持的檔案類型:
-python, javascript, html, css, typescript, java, cpp, c, go, rust, ruby, php, swift, kotlin, sql, shell, yaml, json, xml, markdown, text
-
-記住:
-- 只輸出有效的 JSON,不要有額外的文字或 markdown 格式
-- 確保程式碼正確格式化,縮排正確
-- 在程式碼字串中使用真實的換行符號,而不是 \\n 文字
-- 對於網頁應用,仔細考慮獨立瀏覽器視窗的能力
-- **Flask/Web 伺服器絕對不要使用 debug=True**
-
-對於 HTML + 後端專案的特別注意事項:
-1. 確保後端伺服器(Flask/Node.js)正確配置 CORS 和靜態檔案服務
-2. HTML 檔案應該正確引用後端 API 端點
-3. 提供完整的前後端連接測試程式碼
-4. 在 run_instructions 中明確說明:
-   - 先啟動後端伺服器
-   - 後端服務地址
-   - 前端如何訪問
-5. 對於需要同時運行前後端的專案:
-   - 後端檔案設定 is_web_app: true, can_open_standalone: false
-   - 提供準確的 server_address 和 web_title
-   - 確保後端程式碼包含適當的路由和 CORS 設定
-   - **後端絕對不要使用 debug=True**
-6. 測試程式碼應該驗證:
-   - 後端伺服器啟動成功
-   - API 端點可訪問
-   - 前後端數據交互正常
-
-Terminal 輸出和除錯資訊:
-1. 所有重要的執行步驟都應該有 print() 或 console.log() 輸出
-2. 包含適當的錯誤處理和錯誤訊息輸出
-3. 啟動時輸出服務地址和狀態資訊
-4. 對於網頁應用,輸出 "伺服器運行於: http://localhost:PORT"
-"""
+請以這個全新結構回覆,不要沿用舊版模板或刪減任何必要欄位。"""
 
 # ============================================
 # 配置管理模塊
@@ -429,7 +438,7 @@ class ConversationManager:
     def load_conversation(project_dir: str) -> ProjectConversation:
         """載入專案對話歷史 - 正確處理 usage_metadata"""
         conv_file = ConversationManager.get_conversation_file(project_dir)
-        
+
         if not conv_file.exists():
             project_name = Path(project_dir).name
             conv = ProjectConversation(
@@ -466,7 +475,9 @@ class ConversationManager:
                     project_name=data['project_name'],
                     messages=messages,
                     created_at=data.get('created_at', ''),
-                    updated_at=data.get('updated_at', '')
+                    updated_at=data.get('updated_at', ''),
+                    memory_snapshot=data.get('memory_snapshot', {}),
+                    evaluation_snapshot=data.get('evaluation_snapshot', {})
                 )
         except Exception as e:
             logger.error(f"載入對話歷史失敗: {e}")
@@ -503,9 +514,11 @@ class ConversationManager:
                 'project_name': conversation.project_name,
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'memory_snapshot': conversation.memory_snapshot,
+                'evaluation_snapshot': conversation.evaluation_snapshot
             }
-            
+
             with open(conv_file, 'w', encoding='utf-8') as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
             
@@ -533,6 +546,20 @@ class ConversationManager:
         )
         
         conversation.messages.append(message)
+        ConversationManager.save_conversation(conversation)
+
+    @staticmethod
+    def update_memory_state(project_dir: str, memory_snapshot: Optional[Dict], evaluation_snapshot: Optional[Dict]):
+        """更新對話的記憶與評分快照"""
+        conversation = ConversationManager.load_conversation(project_dir)
+
+        if memory_snapshot:
+            conversation.memory_snapshot = memory_snapshot
+        if evaluation_snapshot:
+            conversation.evaluation_snapshot = {
+                k: v for k, v in (evaluation_snapshot or {}).items() if v is not None
+            }
+
         ConversationManager.save_conversation(conversation)
     
     @staticmethod
@@ -683,6 +710,225 @@ class ProjectManager:
         except Exception as e:
             logger.error(f"移除專案失敗: {e}")
             return False
+
+# ============================================
+# 語法偵錯管理
+# ============================================
+
+class DiagnosticsManager:
+    """語法偵錯管理器,針對常見語言提供基礎語法檢查"""
+
+    EXCLUDE_NAMES = {'PROJECT_INFO.json', '__pycache__', '.git', 'node_modules', 'venv', '.vscode'}
+
+    HANDLERS = {}
+
+    @staticmethod
+    def _truncate(text: str, limit: int = 180) -> str:
+        if len(text) <= limit:
+            return text
+        return text[:limit - 1] + '…'
+
+    @staticmethod
+    def _check_python(file_path: Path) -> Tuple[str, str]:
+        try:
+            source = file_path.read_text(encoding='utf-8')
+        except Exception as e:
+            return 'warning', f'無法讀取檔案: {e}'
+
+        try:
+            compile(source, str(file_path), 'exec')
+            return 'passed', '語法檢查通過'
+        except SyntaxError as e:
+            line = e.lineno or 0
+            column = e.offset or 0
+            message = f'SyntaxError 第 {line} 行第 {column} 欄: {e.msg}'
+            return 'failed', message
+        except Exception as e:
+            return 'warning', DiagnosticsManager._truncate(str(e))
+
+    @staticmethod
+    def _check_json(file_path: Path) -> Tuple[str, str]:
+        try:
+            text = file_path.read_text(encoding='utf-8')
+            json.loads(text)
+            return 'passed', 'JSON 結構有效'
+        except json.JSONDecodeError as e:
+            message = f'JSONDecodeError 第 {e.lineno} 行第 {e.colno} 欄: {e.msg}'
+            return 'failed', message
+        except Exception as e:
+            return 'warning', DiagnosticsManager._truncate(str(e))
+
+    @staticmethod
+    def _check_toml(file_path: Path) -> Tuple[str, str]:
+        try:
+            import tomllib
+        except ModuleNotFoundError:
+            return 'warning', 'Python 版本不支援 tomllib,略過檢查'
+
+        try:
+            with open(file_path, 'rb') as f:
+                tomllib.load(f)
+            return 'passed', 'TOML 結構有效'
+        except (tomllib.TOMLDecodeError, ValueError) as e:
+            return 'failed', DiagnosticsManager._truncate(str(e))
+        except Exception as e:
+            return 'warning', DiagnosticsManager._truncate(str(e))
+
+    @staticmethod
+    def _check_css(file_path: Path) -> Tuple[str, str]:
+        try:
+            text = file_path.read_text(encoding='utf-8')
+        except Exception as e:
+            return 'warning', f'無法讀取檔案: {e}'
+
+        opens = text.count('{')
+        closes = text.count('}')
+        if opens != closes:
+            return 'failed', f'大括號數量不一致: 開啟 {opens} 個, 關閉 {closes} 個'
+
+        if text.count('/*') != text.count('*/'):
+            return 'warning', '偵測到未封閉的註解,請人工確認'
+
+        return 'passed', '基本語法檢查通過'
+
+    @staticmethod
+    def _check_html(file_path: Path) -> Tuple[str, str]:
+        try:
+            text = file_path.read_text(encoding='utf-8')
+        except Exception as e:
+            return 'warning', f'無法讀取檔案: {e}'
+
+        if text.count('<') != text.count('>'):
+            return 'failed', '角括號數量不一致,可能存在未閉合標籤'
+
+        if '</html>' not in text.lower():
+            return 'warning', '未偵測到 </html> 結尾,請確認結構是否完整'
+
+        return 'passed', '未發現明顯的標記不一致,建議仍進行人工驗證'
+
+    @staticmethod
+    def _check_js(file_path: Path) -> Tuple[str, str]:
+        if not shutil.which('node'):
+            return 'warning', '未安裝 Node.js,無法自動進行 JS 語法檢查'
+
+        try:
+            completed = subprocess.run(
+                ['node', '--check', str(file_path)],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+        except subprocess.TimeoutExpired:
+            return 'warning', 'Node.js 檢查逾時,請手動確認'
+        except Exception as e:
+            return 'warning', DiagnosticsManager._truncate(str(e))
+
+        if completed.returncode == 0:
+            return 'passed', 'Node.js 語法檢查通過'
+
+        message = completed.stderr.strip() or completed.stdout.strip() or 'Node.js 檢查失敗'
+        return 'failed', DiagnosticsManager._truncate(message)
+
+    @staticmethod
+    def _check_ts(file_path: Path) -> Tuple[str, str]:
+        if not shutil.which('tsc'):
+            return 'warning', '未安裝 TypeScript 編譯器 (tsc),略過檢查'
+
+        try:
+            completed = subprocess.run(
+                ['tsc', '--pretty', 'false', '--noEmit', str(file_path)],
+                capture_output=True,
+                text=True,
+                timeout=15
+            )
+        except subprocess.TimeoutExpired:
+            return 'warning', 'tsc 檢查逾時,請手動確認'
+        except Exception as e:
+            return 'warning', DiagnosticsManager._truncate(str(e))
+
+        if completed.returncode == 0:
+            return 'passed', 'TypeScript 語法檢查通過'
+
+        message = completed.stderr.strip() or completed.stdout.strip() or 'tsc 檢查失敗'
+        return 'failed', DiagnosticsManager._truncate(message)
+
+    @staticmethod
+    def _not_supported(language: str) -> Tuple[str, str]:
+        return 'warning', f'暫不支援自動偵錯 {language} 檔案,請人工確認'
+
+    @classmethod
+    def collect(cls, project_dir: str) -> Tuple[List[Dict[str, Any]], str]:
+        """收集語法偵錯結果,並回傳報告與提示文本"""
+        base_path = Path(project_dir)
+        if not base_path.exists():
+            return [], ''
+
+        handlers = {
+            '.py': ('Python', cls._check_python),
+            '.json': ('JSON', cls._check_json),
+            '.toml': ('TOML', cls._check_toml),
+            '.css': ('CSS', cls._check_css),
+            '.html': ('HTML', cls._check_html),
+            '.htm': ('HTML', cls._check_html),
+            '.js': ('JavaScript', cls._check_js),
+            '.mjs': ('JavaScript', cls._check_js),
+            '.cjs': ('JavaScript', cls._check_js),
+            '.ts': ('TypeScript', cls._check_ts),
+            '.tsx': ('TypeScript (TSX)', lambda path: cls._not_supported('TSX')),  # 需 Babel 或專用工具
+            '.jsx': ('JavaScript (JSX)', lambda path: cls._not_supported('JSX'))
+        }
+
+        results: List[Dict[str, Any]] = []
+
+        for file_path in base_path.rglob('*'):
+            if not file_path.is_file():
+                continue
+
+            if file_path.name in cls.EXCLUDE_NAMES or any(ex in file_path.parts for ex in cls.EXCLUDE_NAMES):
+                continue
+
+            suffix = file_path.suffix.lower()
+            if suffix not in handlers:
+                continue
+
+            language, handler = handlers[suffix]
+
+            try:
+                status, message = handler(file_path)
+            except Exception as e:
+                status, message = 'warning', f'檢查時發生錯誤: {e}'
+
+            results.append({
+                'file': str(file_path.relative_to(base_path)),
+                'language': language,
+                'status': status,
+                'message': message
+            })
+
+        prompt_block = cls._format_prompt(results)
+        return results, prompt_block
+
+    @classmethod
+    def _format_prompt(cls, results: List[Dict[str, Any]]) -> str:
+        if not results:
+            return ''
+
+        icon_map = {
+            'passed': '✅',
+            'failed': '❌',
+            'warning': '⚠️',
+            'skipped': 'ℹ️'
+        }
+
+        lines = ['【語法偵錯結果】']
+        for item in results:
+            icon = icon_map.get(item.get('status'), '•')
+            language = item.get('language', '未知語言')
+            file_name = item.get('file', '未知檔案')
+            message = item.get('message', '')
+            lines.append(f"{icon} [{language}] {file_name} -> {message}")
+
+        return '\n'.join(lines)
 
 # ============================================
 # Gemini AI 模塊
@@ -1122,16 +1368,17 @@ class CodeProcessor:
     def parse_json_response(json_data: Dict) -> ProjectOutput:
         """解析 JSON 格式的 AI 回應"""
         try:
+            project_section = json_data.get('專案輸出', json_data)
             files = []
-            for file_data in json_data.get('files', []):
+            for file_data in project_section.get('files', []):
                 code = file_data.get('code', '')
-                
+
                 if isinstance(code, str):
                     code = code.replace('\\n', '\n')
                     code = code.replace('\\t', '\t')
                     code = code.replace('\\"', '"')
                     code = code.replace("\\'", "'")
-                
+
                 files.append(FileOutput(
                     filename=file_data.get('filename', 'untitled.txt'),
                     filetype=file_data.get('filetype', 'text'),
@@ -1147,16 +1394,16 @@ class CodeProcessor:
                     server_address=file_data.get('server_address'),
                     web_title=file_data.get('web_title')
                 ))
-            
+
             return ProjectOutput(
-                project_name=json_data.get('project_name', 'untitled_project'),
-                description=json_data.get('description', ''),
+                project_name=project_section.get('project_name', 'untitled_project'),
+                description=project_section.get('description', ''),
                 files=files,
-                main_file=json_data.get('main_file'),
-                setup_instructions=json_data.get('setup_instructions'),
-                run_instructions=json_data.get('run_instructions')
+                main_file=project_section.get('main_file'),
+                setup_instructions=project_section.get('setup_instructions'),
+                run_instructions=project_section.get('run_instructions')
             )
-        
+
         except Exception as e:
             logger.error(f"解析 JSON 回應失敗: {e}")
             raise
@@ -1660,20 +1907,34 @@ class ProcessManager:
         files: List[Dict] = None,
         is_iteration: bool = False,
         attach_screenshot: bool = False,
-        attach_terminal: bool = False
+        attach_terminal: bool = False,
+        attach_diagnostics: bool = False,
+        user_visible_prompt: Optional[str] = None,
+        memory_context: Optional[str] = None
     ) -> ProcessResult:
         """執行完整的自動化流程 - 修復版"""
         
         result = ProcessResult(success=False, is_iteration=is_iteration)
         
         try:
+            files = list(files or [])
+            user_files_snapshot = list(files)
+
+            diagnostics_report: List[Dict[str, Any]] = []
+            diagnostics_prompt_block = ''
+
+            if attach_diagnostics:
+                diagnostics_report, diagnostics_prompt_block = DiagnosticsManager.collect(folder_path)
+                result.diagnostics_report = diagnostics_report
+                if diagnostics_prompt_block:
+                    prompt = f"{diagnostics_prompt_block}\n\n{prompt}"
             if is_iteration:
                 logger.info("迭代模式:自動載入專案所有檔案")
                 project_files = ProjectManager.load_project_files(folder_path)
-                
+
                 if not files:
                     files = []
-                
+
                 files.extend(project_files)
                 logger.info(f"已附加 {len(project_files)} 個專案檔案")
             
@@ -1683,14 +1944,23 @@ class ProcessManager:
                 if terminal_output:
                     logger.info("已附加Terminal輸出到AI請求")
                     result.terminal_output = terminal_output
-            
+
             # ⭐ 修復:在正確的時機保存用戶消息
+            display_prompt = user_visible_prompt or prompt
+
+            metadata_payload = {}
+            if memory_context:
+                metadata_payload['memory_context'] = memory_context
+            if diagnostics_report:
+                metadata_payload['diagnostics_report'] = diagnostics_report
+
             ConversationManager.add_message(
                 folder_path,
                 'user',
-                prompt,
-                files=[{'name': f.get('name'), 'type': f.get('type')} for f in (files or [])],
-                terminal_output=terminal_output
+                display_prompt,
+                files=[{'name': f.get('name'), 'type': f.get('type')} for f in user_files_snapshot],
+                terminal_output=terminal_output,
+                metadata=metadata_payload if metadata_payload else None
             )
             
             if is_iteration and attach_screenshot:
@@ -1763,14 +2033,34 @@ class ProcessManager:
                 prompt, config, files, terminal_output
             )
             result.ai_response = ai_response
-            result.ai_response_json = json_data
             result.usage_metadata = usage_metadata
-            
+
+            normalized_json = {}
+            if json_data:
+                if isinstance(json_data, list):
+                    normalized_json = json_data[0] if json_data else {}
+                else:
+                    normalized_json = json_data
+
+            if normalized_json:
+                memory_snapshot = normalized_json.get('核心記憶模塊') or normalized_json.get('core_memory_module')
+                evaluation_snapshot = {
+                    '評分': normalized_json.get('評分'),
+                    '內容評價': normalized_json.get('內容評價'),
+                    '扣分原因': normalized_json.get('扣分原因'),
+                    '改進建議': normalized_json.get('改進建議')
+                }
+                evaluation_snapshot = {k: v for k, v in evaluation_snapshot.items() if v is not None}
+                result.memory_snapshot = memory_snapshot
+                result.evaluation_snapshot = evaluation_snapshot
+
+            result.ai_response_json = normalized_json if normalized_json else None
+
             logger.info("Step 2: 解析 AI 回應...")
             try:
-                if json_data:
+                if normalized_json:
                     logger.info("使用 JSON 模式解析")
-                    project = CodeProcessor.parse_json_response(json_data)
+                    project = CodeProcessor.parse_json_response(normalized_json)
                 else:
                     logger.info("嘗試從文本中提取 JSON")
                     try:
@@ -1781,8 +2071,10 @@ class ProcessManager:
                             json_str = json_str.replace('\\n', '\n')
                             json_str = json_str.replace('\\t', '\t')
                             potential_json = json.loads(json_str)
+                            if isinstance(potential_json, list):
+                                potential_json = potential_json[0] if potential_json else {}
                             project = CodeProcessor.parse_json_response(potential_json)
-                            result.ai_response_json = potential_json
+                            result.ai_response_json = potential_json or None
                             logger.info("成功從文本中提取並解析 JSON")
                         else:
                             raise ValueError("無法從回應中找到有效的JSON結構")
@@ -2055,12 +2347,21 @@ class ProcessManager:
                 result.output,
                 metadata={
                     'project_name': project.project_name,
-                    'files_count': len(project.files)
+                    'files_count': len(project.files),
+                    **({'memory_snapshot': result.memory_snapshot} if result.memory_snapshot else {}),
+                    **({'evaluation_snapshot': result.evaluation_snapshot} if result.evaluation_snapshot else {})
                 },
                 terminal_output=result.terminal_output,
                 usage_metadata=usage_metadata  # ⭐ 直接傳遞 usage_metadata
             )
-            
+
+            if result.memory_snapshot or result.evaluation_snapshot:
+                ConversationManager.update_memory_state(
+                    final_project_dir,
+                    result.memory_snapshot,
+                    result.evaluation_snapshot
+                )
+
         except Exception as e:
             result.error = str(e)
             logger.error(f"處理流程失敗: {e}")
@@ -2189,7 +2490,9 @@ def load_project():
             'conversation': {
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'memory_snapshot': conversation.memory_snapshot,
+                'evaluation_snapshot': conversation.evaluation_snapshot
             }
         })
         
@@ -2229,7 +2532,9 @@ def get_conversation(project_dir):
                 'project_name': conversation.project_name,
                 'messages': messages_data,
                 'created_at': conversation.created_at,
-                'updated_at': conversation.updated_at
+                'updated_at': conversation.updated_at,
+                'memory_snapshot': conversation.memory_snapshot,
+                'evaluation_snapshot': conversation.evaluation_snapshot
             }
         })
     except Exception as e:
@@ -2287,12 +2592,15 @@ def run_process():
         
         folder_path = data.get('folder_path')
         prompt = data.get('prompt')
+        display_prompt = data.get('display_prompt')
+        memory_context = data.get('memory_context')
         config_data = data.get('config', {})
         files = data.get('files', [])
         is_iteration = data.get('is_iteration', False)
         attach_screenshot = data.get('attach_screenshot', False)
         attach_terminal = data.get('attach_terminal', False)
-        
+        attach_diagnostics = data.get('attach_diagnostics', False)
+
         if not all([folder_path, prompt]):
             return jsonify({
                 'success': False,
@@ -2309,9 +2617,12 @@ def run_process():
             files,
             is_iteration,
             attach_screenshot,
-            attach_terminal
+            attach_terminal,
+            attach_diagnostics,
+            user_visible_prompt=display_prompt,
+            memory_context=memory_context
         )
-        
+
         response_data = {
             'success': result.success,
             'output': result.output,
@@ -2324,8 +2635,13 @@ def run_process():
             'screenshots': result.screenshots,
             'is_iteration': result.is_iteration,
             'usage_metadata': result.usage_metadata,
-            'terminal_output': result.terminal_output
+            'terminal_output': result.terminal_output,
+            'memory_snapshot': result.memory_snapshot,
+            'evaluation_snapshot': result.evaluation_snapshot
         }
+
+        if attach_diagnostics:
+            response_data['diagnostics_report'] = result.diagnostics_report
         
         if result.project_data:
             response_data['project'] = {

--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -141,6 +141,7 @@ class AIConfig:
     gemini_api_key: str = ""
     model_name: str = "gemini-2.5-pro"
     system_instruction: str = ""
+    prompt_mode: str = "default"
     generation_params: Dict[str, Any] = None
     thinking_config: Dict[str, Any] = None
     safety_settings: Dict[str, str] = None
@@ -175,6 +176,13 @@ class AIConfig:
                 "auto_test": False,
                 "monitor_interval": 5
             }
+
+        if not self.prompt_mode:
+            self.prompt_mode = "default"
+        else:
+            self.prompt_mode = str(self.prompt_mode).lower()
+            if self.prompt_mode not in {"default", "creative"}:
+                self.prompt_mode = "default"
 
 @dataclass
 class ConversationMessage:
@@ -306,36 +314,41 @@ def get_json_schema():
         "required": ["評分", "內容評價", "扣分原因", "改進建議", "核心記憶模塊", "專案輸出"]
     }
 
-def get_json_system_instruction():
-    """獲取 JSON 模式的系統指令 - 繁體中文版 + Flask修復"""
-    return """你是一位專業的程式碼與專案助理,負責在每次回應中同時提供程式碼成果、評分與記憶管理資訊,並優先根據最新的語法偵錯結果修復問題。
+def get_json_system_instruction(mode: str = "default", custom_instruction: str = "") -> str:
+    """獲取 JSON 模式的系統指令,支援多種提示詞模式"""
 
-請務必輸出**單一 JSON 物件**,欄位結構如下:
+    normalized_mode = (mode or "default").lower()
+    if normalized_mode not in {"default", "creative"}:
+        normalized_mode = "default"
+
+    base_instruction = """你是一位專業的程式碼與專案助理,必須在每次回應中提供完整可執行的程式碼成果、評分紀錄與記憶模塊。請永遠僅輸出**單一 JSON 物件**,並優先依照最新語法偵錯結果修復問題。凡涉及使用者介面或視覺呈現的需求,都要先審視互動流程與美感再撰寫程式,必要時主動調整佈局、動畫與可用性細節。
+
+JSON 結構必須包含以下欄位:
 {
-  "評分": 0-100 的整數,
-  "內容評價": "200 字內的綜合評論",
-  "扣分原因": "若無扣分請填『無』",
-  "改進建議": "下一次回應可改進的方向,若無請填『無』",
+  "評分": 0-100 的整數 (採保守原則,除非品質極佳,否則分數傾向較低),
+  "內容評價": "200 字內的規則遵守與內容品質評語",
+  "扣分原因": "具體說明扣分項,若無填『無』",
+  "改進建議": "聚焦於下一輪可新增的功能或體驗強化,不得僅提程式碼微調,若全數達成可填『無』",
   "核心記憶模塊": {
-      "專案總結": "摘要最新對話或專案重點",
-      "短期記憶": ["依照條列方式列出最近幾輪對話的關鍵資訊"...],
-      "長期記憶": ["以條列方式描述專案背景、核心目標或重要限制"...],
+      "專案總結": "簡述當前或上一輪的核心進展",
+      "短期記憶": ["以條列方式列出最近數輪對話的關鍵決策或限制"],
+      "長期記憶": ["條列專案背景、核心目標、重要限制或失敗教訓"],
       "專案目標": [
-          {"步驟": 1, "任務": "...", "狀態": "已完成/進行中/未開始", "是否為當前任務": true/false},
-          {"步驟": 2, ... 至少四個項目}
+          {"步驟": 1, "任務": "具體任務描述", "狀態": "已完成/進行中/未開始", "是否為當前任務": true/false},
+          {"步驟": 2, ... 至少四個項目,需依最新進度更新狀態}
       ]
   },
   "專案輸出": {
       "project_name": "專案名稱",
-      "description": "簡要描述",
+      "description": "專案描述",
       "main_file": "主要程式檔案名稱",
-      "setup_instructions": ["pip install package1"...],
+      "setup_instructions": ["pip install package"...],
       "run_instructions": ["python main.py"...],
       "files": [
           {
-              "filename": "檔案名稱(含副檔名)",
+              "filename": "含副檔名的檔案名稱",
               "filetype": "python/javascript/...",
-              "code": "完整無省略程式碼,使用實際換行符號",
+              "code": "完整無省略的繁體中文註解程式碼,使用真實換行符號",
               "opens_window": true/false,
               "window_title": null 或字串,
               "install_requirements": ["pip install ..."],
@@ -351,21 +364,56 @@ def get_json_system_instruction():
   }
 }
 
-執行規範:
-1. 僅能輸出有效 JSON,不得加入多餘文字、註解或 Markdown。
-2. 若提供語法偵錯結果,請優先修正其中列出的錯誤或警告,並在回應中說明修正方式。
-3. "短期記憶" 與 "長期記憶" 必須為字串陣列,每個元素對應一項條列內容,不得回傳空字串;若沒有資料請輸出空陣列 []。
-4. "files" 內的程式碼必須為完整、可執行、無省略號的繁體中文註解或文字,並以真實 \n 代表換行、\t 代表縮排。
-5. 若為 Flask/Node 等伺服器程式,禁止使用 debug=True 或熱重載模式,Flask 必須採用 `app.run(host='0.0.0.0', port=5000)`。
-6. 所有網頁相關檔案需填寫 `is_web_app`, 並在必要時提供 `server_address` 與 `web_title`。
-7. 任何需要額外套件的檔案,必須在 `install_requirements` 中完整列出安裝指令。
-8. 多檔案專案需確保相依檔案之間的匯入路徑正確,不得遺漏必要資源。
-9. 所有字串請使用繁體中文說明,除非程式語言語法或函式庫名稱要求英文。
-10. 專案目標需依進度更新狀態,並清楚標示當前主要任務。
-11. 評分、扣分原因、改進建議需與本次回覆內容一致,不得空泛。
+核心規範:
+1. 僅能輸出有效 JSON,禁止夾帶 Markdown、註解或額外文字。
+2. "短期記憶" 與 "長期記憶" 必須為字串陣列,若無資料請回傳 []。
+3. `files[].code` 需為完整可執行內容,不得出現省略號,並以 
+ 表示換行、	 表示縮排。
+4. 有使用者介面或畫面輸出的程式,需優先考量互動性、響應式設計與視覺層次,必要時補充微動畫、狀態提示或無障礙設計。
+5. 為確保跨系統穩定性,所有 Windows/Tkinter/Flask 等程式需避免 debug 模式,Flask 必須採用 `app.run(host='0.0.0.0', port=5000)`。
+6. 任何額外套件皆需列於 `install_requirements`,並同步於 `dependencies` 註明。
+7. 專案目標需隨進度更新狀態與「是否為當前任務」標記。
+8. 評分、扣分原因、改進建議需具體且對應本輪輸出,不得空泛或自我矛盾。
 
-請以這個全新結構回覆,不要沿用舊版模板或刪減任何必要欄位。"""
+模式加值指引:"""
 
+    if normalized_mode == "creative":
+        mode_instruction = """【模式：創意模式】
+- 在滿足基本可靠性的前提下,勇於提出跨平台或體驗導向的新功能,例如進階互動、動畫、個人化設定或整合第三方服務。
+- 改進建議應優先探索尚未實作的突破性能力,鼓勵 AI 於下一輪實驗創新解法,同時說明預期價值與使用者體驗。"""
+    else:
+        mode_instruction = """【模式：預設模式】
+- 保持穩健與可維護性,逐步完善現有需求並確保相容性與測試覆蓋。
+- 改進建議應聚焦於補齊缺失的必要功能或實用增強,並在實作前再次檢查使用者介面是否達到優雅且易用。"""
+
+    custom_block = ""
+    if custom_instruction:
+        custom_block = f"\n【使用者自訂補充】\n{custom_instruction.strip()}"
+
+    return "\n".join([
+        base_instruction,
+        mode_instruction,
+        "請以此最新模板回覆,不得沿用舊版提示詞或遺漏欄位。" + custom_block
+    ])
+
+
+def sanitize_json_strings(data: Any) -> Any:
+    """將字串中的控制符號轉換成安全的跳脫字元"""
+
+    if isinstance(data, dict):
+        return {key: sanitize_json_strings(value) for key, value in data.items()}
+
+    if isinstance(data, list):
+        return [sanitize_json_strings(item) for item in data]
+
+    if isinstance(data, str):
+        sanitized = data.replace('\r\n', '\n')
+        sanitized = sanitized.replace('\r', '\\r')
+        sanitized = sanitized.replace('\n', '\\n')
+        sanitized = sanitized.replace('\t', '\\t')
+        return sanitized
+
+    return data
 # ============================================
 # 配置管理模塊
 # ============================================
@@ -970,7 +1018,10 @@ class GeminiAI:
             gen_params = dict(config.generation_params)
             gen_params["response_mime_type"] = "application/json"
             
-            system_instruction = get_json_system_instruction()
+            system_instruction = get_json_system_instruction(
+                getattr(config, 'prompt_mode', 'default'),
+                config.system_instruction
+            )
             
             gen_config = GenerationConfig(**{
                 k: v for k, v in gen_params.items() if v is not None
@@ -2042,25 +2093,27 @@ class ProcessManager:
                 else:
                     normalized_json = json_data
 
-            if normalized_json:
-                memory_snapshot = normalized_json.get('核心記憶模塊') or normalized_json.get('core_memory_module')
+            sanitized_json = sanitize_json_strings(normalized_json) if normalized_json else None
+
+            if sanitized_json:
+                memory_snapshot = sanitized_json.get('核心記憶模塊') or sanitized_json.get('core_memory_module')
                 evaluation_snapshot = {
-                    '評分': normalized_json.get('評分'),
-                    '內容評價': normalized_json.get('內容評價'),
-                    '扣分原因': normalized_json.get('扣分原因'),
-                    '改進建議': normalized_json.get('改進建議')
+                    '評分': sanitized_json.get('評分'),
+                    '內容評價': sanitized_json.get('內容評價'),
+                    '扣分原因': sanitized_json.get('扣分原因'),
+                    '改進建議': sanitized_json.get('改進建議')
                 }
                 evaluation_snapshot = {k: v for k, v in evaluation_snapshot.items() if v is not None}
                 result.memory_snapshot = memory_snapshot
                 result.evaluation_snapshot = evaluation_snapshot
 
-            result.ai_response_json = normalized_json if normalized_json else None
+            result.ai_response_json = sanitized_json if sanitized_json else None
 
             logger.info("Step 2: 解析 AI 回應...")
             try:
-                if normalized_json:
+                if sanitized_json:
                     logger.info("使用 JSON 模式解析")
-                    project = CodeProcessor.parse_json_response(normalized_json)
+                    project = CodeProcessor.parse_json_response(sanitized_json)
                 else:
                     logger.info("嘗試從文本中提取 JSON")
                     try:
@@ -2073,8 +2126,9 @@ class ProcessManager:
                             potential_json = json.loads(json_str)
                             if isinstance(potential_json, list):
                                 potential_json = potential_json[0] if potential_json else {}
-                            project = CodeProcessor.parse_json_response(potential_json)
-                            result.ai_response_json = potential_json or None
+                            sanitized_potential = sanitize_json_strings(potential_json)
+                            project = CodeProcessor.parse_json_response(sanitized_potential)
+                            result.ai_response_json = sanitized_potential or None
                             logger.info("成功從文本中提取並解析 JSON")
                         else:
                             raise ValueError("無法從回應中找到有效的JSON結構")
@@ -2088,23 +2142,23 @@ class ProcessManager:
                 result.error = f"解析失敗: {str(parse_error)}"
                 
                 error_details = f"""
-=== ❌ 解析錯誤 ===
-{parse_error}
+                === \u274c 解析錯誤 ===
+                {parse_error}
 
-=== 🔍 可能的原因 ===
-1. AI 回應格式不正確
-2. JSON 結構有誤
-3. 程式碼格式化問題
+                === \U0001f50d 可能的原因 ===
+                1. AI 回應格式不正確
+                2. JSON 結構有誤
+                3. 程式碼格式化問題
 
-=== 💡 解決建議 ===
-1. 嘗試切換到文本模式
-2. 調整 AI 模型(建議使用 Gemini 2.5 Pro)
-3. 簡化您的需求描述
-4. 檢查 API Key 是否有效
+                === \U0001f4a1 解決建議 ===
+                1. 嘗試切換到文本模式
+                2. 調整 AI 模型(建議使用 Gemini 2.5 Pro)
+                3. 簡化您的需求描述
+                4. 檢查 API Key 是否有效
 
-=== 🤖 AI 原始回應 ===
-請查看下方「AI 回應」區域以檢視完整內容。
-"""
+                === \U0001f916 AI 原始回應 ===
+                請查看下方「AI 回應」區域以檢視完整內容。
+                """
                 
                 result.output = error_details
                 

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -1409,7 +1409,12 @@ async function loadSettings() {
         
         document.getElementById('apiKey').value = config.gemini_api_key || '';
         document.getElementById('modelName').value = config.model_name || 'gemini-2.5-pro';
-        
+
+        const promptModeSelect = document.getElementById('promptMode');
+        if (promptModeSelect) {
+            promptModeSelect.value = config.prompt_mode || 'default';
+        }
+
         const genParams = config.generation_params || {};
         document.getElementById('temperature').value = genParams.temperature || 0.7;
         document.getElementById('topP').value = genParams.top_p || 0.95;
@@ -1446,6 +1451,7 @@ async function saveSettings() {
             connection_method: 'api_key',
             gemini_api_key: document.getElementById('apiKey').value,
             model_name: document.getElementById('modelName').value,
+            prompt_mode: (document.getElementById('promptMode')?.value || 'default'),
             generation_params: {
                 temperature: parseFloat(document.getElementById('temperature').value),
                 top_p: parseFloat(document.getElementById('topP').value),

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -9,10 +9,14 @@ let isIterationMode = false;
 let currentProjectDir = null;
 let autoScreenshot = false;
 let attachTerminal = false;
+let attachDiagnostics = false;
 let allProjects = [];
 let modelConfig = null;
 let sidebarCollapsed = false;
 let MODEL_LIMITS = {};
+let projectMemoryState = {};
+let autoAttachMemory = true;
+const messageDiagnosticsHolderMap = new WeakMap();
 
 // ============================================
 // Loading Overlay 控制 - 修復版
@@ -48,6 +52,13 @@ window.addEventListener('DOMContentLoaded', () => {
     loadProjectsList();
     checkRunningPrograms();
     setInterval(checkRunningPrograms, 5000);
+
+    const memoryMenuItem = document.getElementById('memoryMenuItem');
+    if (memoryMenuItem) {
+        memoryMenuItem.classList.add('active');
+    }
+    updateMemoryMenuHint();
+    renderMemoryPanel();
     
     // 點擊外部關閉選單
     document.addEventListener('click', (e) => {
@@ -279,6 +290,316 @@ function toggleAttachTerminal() {
     togglePlusMenu();
 }
 
+function toggleAttachDiagnostics() {
+    attachDiagnostics = !attachDiagnostics;
+    const menuItem = document.getElementById('diagnosticsMenuItem');
+    if (menuItem) {
+        if (attachDiagnostics) {
+            menuItem.classList.add('active');
+            showNotification('已啟用語法偵錯結果附加', 'success');
+        } else {
+            menuItem.classList.remove('active');
+            showNotification('已關閉語法偵錯結果附加', 'info');
+        }
+    }
+    togglePlusMenu();
+}
+
+function toggleAutoAttachMemory() {
+    autoAttachMemory = !autoAttachMemory;
+    const menuItem = document.getElementById('memoryMenuItem');
+    if (menuItem) {
+        if (autoAttachMemory) {
+            menuItem.classList.add('active');
+            showNotification('已啟用自動附加記憶上下文', 'success');
+        } else {
+            menuItem.classList.remove('active');
+            showNotification('已關閉自動附加記憶上下文', 'info');
+        }
+    }
+    togglePlusMenu();
+}
+
+function diagnosticsStatusIcon(status) {
+    switch (status) {
+        case 'passed':
+            return '✅';
+        case 'failed':
+            return '❌';
+        case 'warning':
+            return '⚠️';
+        case 'skipped':
+            return 'ℹ️';
+        default:
+            return '•';
+    }
+}
+
+function applyDiagnosticsToMessage(messageElement, report = []) {
+    if (!messageElement) return;
+    const holder = messageDiagnosticsHolderMap.get(messageElement);
+    if (!holder) return;
+
+    holder.innerHTML = '';
+
+    const safeReport = Array.isArray(report) ? report : [];
+    const details = document.createElement('details');
+    details.className = 'diagnostics-details';
+    if (safeReport.some(item => item && item.status === 'failed')) {
+        details.open = true;
+    }
+
+    const summary = document.createElement('summary');
+    const count = safeReport.length;
+    summary.textContent = `語法偵錯結果（${count}）`;
+    details.appendChild(summary);
+
+    if (count === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'diagnostics-empty';
+        empty.textContent = '未找到可用的語法偵錯資訊，請確認專案檔案是否支援自動檢查。';
+        details.appendChild(empty);
+    } else {
+        const list = document.createElement('ul');
+        list.className = 'diagnostics-list';
+
+        safeReport.forEach(item => {
+            if (!item) return;
+            const listItem = document.createElement('li');
+            listItem.className = 'diagnostics-item';
+
+            const status = item.status || 'info';
+            listItem.dataset.status = status;
+
+            const icon = document.createElement('span');
+            icon.className = 'diagnostics-icon';
+            icon.textContent = diagnosticsStatusIcon(status);
+
+            const content = document.createElement('div');
+            content.className = 'diagnostics-content';
+
+            const header = document.createElement('div');
+            header.className = 'diagnostics-header';
+            const language = item.language || '未知語言';
+            const fileName = item.file || '未知檔案';
+            header.textContent = `[${language}] ${fileName}`;
+
+            const message = document.createElement('div');
+            message.className = 'diagnostics-message';
+            message.textContent = item.message || '';
+
+            content.append(header, message);
+            listItem.append(icon, content);
+            list.appendChild(listItem);
+        });
+
+        details.appendChild(list);
+    }
+
+    holder.appendChild(details);
+    holder.style.display = 'block';
+}
+
+function getCurrentMemoryState() {
+    if (!currentProjectDir) return null;
+    return projectMemoryState[currentProjectDir] || null;
+}
+
+function setProjectMemoryState(projectDir, memorySnapshot = {}, evaluationSnapshot = {}) {
+    if (!projectDir) return;
+    projectMemoryState[projectDir] = {
+        memory: memorySnapshot || {},
+        evaluation: evaluationSnapshot || {}
+    };
+
+    if (projectDir === currentProjectDir) {
+        updateMemoryMenuHint();
+        renderMemoryPanel();
+    }
+}
+
+function updateMemoryMenuHint() {
+    const hint = document.getElementById('memorySuggestionPreview');
+    if (!hint) return;
+
+    if (!currentProjectDir) {
+        hint.textContent = '上一輪改進建議：尚未選擇專案';
+        hint.title = '';
+        return;
+    }
+
+    const state = getCurrentMemoryState();
+    const suggestion = state?.evaluation?.['改進建議'];
+
+    if (suggestion !== undefined && suggestion !== null && suggestion !== '') {
+        const trimmed = suggestion.length > 40 ? `${suggestion.slice(0, 40)}…` : suggestion;
+        hint.textContent = `上一輪改進建議：${trimmed}`;
+        hint.title = suggestion;
+    } else {
+        hint.textContent = '上一輪改進建議：尚未有資料';
+        hint.title = '';
+    }
+}
+
+function renderMemoryPanel() {
+    const panel = document.getElementById('memoryPanel');
+    const body = document.getElementById('memoryPanelBody');
+    const scoreEl = document.getElementById('memoryScoreDisplay');
+    const projectLabel = document.getElementById('memoryProjectLabel');
+    const evaluationList = document.getElementById('memoryEvaluationList');
+    const summaryBox = document.getElementById('memorySummaryBox');
+    const stmList = document.getElementById('memorySTMList');
+    const ltmList = document.getElementById('memoryLTMList');
+    const goalsList = document.getElementById('memoryGoalsList');
+
+    if (!panel || !body || !scoreEl || !projectLabel || !evaluationList || !summaryBox || !stmList || !ltmList || !goalsList) {
+        return;
+    }
+
+    if (!currentProjectDir) {
+        panel.style.display = 'none';
+        body.style.maxHeight = 'none';
+        return;
+    }
+
+    panel.style.display = 'flex';
+    body.style.maxHeight = 'none';
+    projectLabel.textContent = currentProject?.name || '未命名專案';
+
+    const state = getCurrentMemoryState();
+    const evaluation = state?.evaluation || {};
+    const memory = state?.memory || {};
+
+    const score = evaluation['評分'];
+    scoreEl.textContent = (score !== undefined && score !== null && score !== '') ? `${score} 分` : '--';
+
+    evaluationList.innerHTML = '';
+    const evaluationItems = [
+        { label: '內容評價', value: evaluation['內容評價'] },
+        { label: '扣分原因', value: evaluation['扣分原因'] },
+        { label: '改進建議', value: evaluation['改進建議'] }
+    ];
+
+    let hasEvaluationContent = false;
+    evaluationItems.forEach(item => {
+        const hasValue = item.value || item.value === '無';
+        if (hasValue) {
+            hasEvaluationContent = true;
+            const row = document.createElement('div');
+            row.className = 'memory-evaluation-item';
+            const labelEl = document.createElement('span');
+            labelEl.className = 'memory-eval-label';
+            labelEl.textContent = item.label;
+            const valueEl = document.createElement('span');
+            valueEl.className = 'memory-eval-value';
+            valueEl.textContent = item.value;
+            row.append(labelEl, valueEl);
+            evaluationList.appendChild(row);
+        }
+    });
+
+    if (!hasEvaluationContent) {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'memory-placeholder';
+        placeholder.textContent = '尚未產生評分資訊';
+        evaluationList.appendChild(placeholder);
+    }
+
+    summaryBox.textContent = memory['專案總結'] || '尚未建立專案總結';
+
+    const renderList = (element, data, emptyText) => {
+        if (!element) return;
+        element.innerHTML = '';
+
+        const normalized = Array.isArray(data)
+            ? data.filter(item => item !== null && item !== undefined && `${item}`.trim() !== '')
+            : (data ? [`${data}`] : []);
+
+        if (normalized.length === 0) {
+            const placeholder = document.createElement('li');
+            placeholder.className = 'memory-placeholder';
+            placeholder.textContent = emptyText;
+            element.appendChild(placeholder);
+            return;
+        }
+
+        normalized.forEach(text => {
+            const item = document.createElement('li');
+            item.className = 'memory-bullet-item';
+            item.textContent = text;
+            element.appendChild(item);
+        });
+    };
+
+    renderList(stmList, memory['短期記憶'], '尚未累積短期記憶');
+    renderList(ltmList, memory['長期記憶'], '尚未建立長期記憶');
+
+    goalsList.innerHTML = '';
+    const goals = Array.isArray(memory['專案目標']) ? memory['專案目標'] : [];
+    if (goals.length === 0) {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'memory-placeholder';
+        placeholder.textContent = '尚未設定專案目標';
+        goalsList.appendChild(placeholder);
+    } else {
+        const statusClassWhitelist = new Set(['已完成', '進行中', '未開始']);
+
+        goals.forEach(goal => {
+            const item = document.createElement('div');
+            item.className = 'memory-goal-item';
+
+            const stepEl = document.createElement('div');
+            stepEl.className = 'goal-step';
+            const stepLabel = goal && Object.prototype.hasOwnProperty.call(goal, '步驟')
+                ? `步驟 ${goal['步驟']}`
+                : '步驟 ?';
+            const stepLabelEl = document.createElement('span');
+            stepLabelEl.textContent = stepLabel;
+            stepEl.appendChild(stepLabelEl);
+
+            if (goal && goal['是否為當前任務']) {
+                const badge = document.createElement('span');
+                badge.className = 'goal-current';
+                badge.textContent = '當前';
+                stepEl.appendChild(badge);
+            }
+
+            const taskEl = document.createElement('div');
+            taskEl.className = 'goal-task';
+            taskEl.textContent = goal && goal['任務'] ? goal['任務'] : '未提供任務描述';
+
+            const statusEl = document.createElement('div');
+            statusEl.className = 'goal-status';
+            const statusText = goal && goal['狀態'] ? goal['狀態'] : '未設定';
+            statusEl.textContent = statusText;
+            if (statusClassWhitelist.has(statusText)) {
+                statusEl.classList.add(statusText);
+            }
+
+            item.append(stepEl, taskEl, statusEl);
+            goalsList.appendChild(item);
+        });
+    }
+
+    updateMemoryMenuHint();
+}
+
+function toggleMemoryPanel() {
+    const panel = document.getElementById('memoryPanel');
+    const btn = document.getElementById('memoryCollapseBtn');
+    const layout = document.getElementById('conversationLayout');
+
+    if (!panel || !btn) return;
+
+    const isCollapsed = panel.classList.toggle('collapsed');
+    btn.classList.toggle('collapsed', isCollapsed);
+    btn.setAttribute('aria-expanded', (!isCollapsed).toString());
+
+    if (layout) {
+        layout.classList.toggle('memory-panel-collapsed', isCollapsed);
+    }
+}
+
 function showAdvancedSettings() {
     togglePlusMenu();
     showSettingsModal();
@@ -314,9 +635,9 @@ function handleKeyDown(event) {
 // ============================================
 async function handleSubmit() {
     const input = document.getElementById('mainInput');
-    const prompt = input?.value.trim();
-    
-    if (!prompt) return;
+    const userPrompt = input?.value.trim();
+
+    if (!userPrompt) return;
 
     if (!currentProjectDir) {
         showNotification('請先選擇或創建專案', 'warning');
@@ -327,7 +648,72 @@ async function handleSubmit() {
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
 
-    addMessage('user', prompt);
+    const attachmentsForMessage = uploadedFiles.map(file => ({
+        name: file.name,
+        type: file.type || 'text/plain'
+    }));
+
+    let requestPrompt = userPrompt;
+    let memoryContextBlock = null;
+
+    if (autoAttachMemory) {
+        const state = getCurrentMemoryState();
+        if (state) {
+            const memoryLines = [];
+            const memory = state.memory || {};
+            const evaluation = state.evaluation || {};
+
+            if (memory['專案總結']) {
+                memoryLines.push(`專案總結：${memory['專案總結']}`);
+            }
+            const formatListBlock = (title, raw) => {
+                if (!raw) return null;
+                const items = Array.isArray(raw)
+                    ? raw.filter(item => item !== null && item !== undefined && `${item}`.trim() !== '')
+                    : [`${raw}`];
+
+                if (items.length === 0) return null;
+                const bullet = items.map(item => `- ${item}`).join('\n');
+                return `${title}：\n${bullet}`;
+            };
+
+            const stmBlock = formatListBlock('短期記憶', memory['短期記憶']);
+            if (stmBlock) {
+                memoryLines.push(stmBlock);
+            }
+
+            const ltmBlock = formatListBlock('長期記憶', memory['長期記憶']);
+            if (ltmBlock) {
+                memoryLines.push(ltmBlock);
+            }
+
+            const goals = Array.isArray(memory['專案目標']) ? memory['專案目標'] : [];
+            if (goals.length > 0) {
+                const goalLines = goals.map(goal => {
+                    const currentFlag = goal['是否為當前任務'] ? '【當前任務】' : '';
+                    return `步驟${goal['步驟']} ${goal['任務']} (${goal['狀態'] || '未設定'})${currentFlag}`;
+                });
+                memoryLines.push(`專案目標：\n${goalLines.join('\n')}`);
+            }
+
+            const improvement = evaluation['改進建議'];
+            if (improvement && improvement !== '無') {
+                memoryLines.push(`上一輪改進建議：${improvement}`);
+            }
+
+            if (memoryLines.length > 0) {
+                memoryContextBlock = `【長短期記憶摘要】\n${memoryLines.join('\n')}`;
+                requestPrompt = `${memoryContextBlock}\n\n【使用者請求】\n${userPrompt}`;
+            }
+        }
+    }
+
+    const userMetadata = {};
+    if (memoryContextBlock) {
+        userMetadata.memoryContext = memoryContextBlock;
+    }
+
+    const userMessage = addMessage('user', userPrompt, null, null, attachmentsForMessage, userMetadata);
 
     input.value = '';
     updateSubmitButton();
@@ -343,20 +729,42 @@ async function handleSubmit() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 folder_path: currentProjectDir,
-                prompt: prompt,
+                prompt: requestPrompt,
+                display_prompt: userPrompt,
+                memory_context: memoryContextBlock,
                 config: config,
                 files: uploadedFiles,
                 is_iteration: isIterationMode,
                 attach_screenshot: isIterationMode && autoScreenshot,
-                attach_terminal: attachTerminal
+                attach_terminal: attachTerminal,
+                attach_diagnostics: attachDiagnostics
             })
         });
 
         const result = await response.json();
 
+        if (userMessage) {
+            if (Array.isArray(result.diagnostics_report)) {
+                applyDiagnosticsToMessage(userMessage, result.diagnostics_report);
+            } else if (attachDiagnostics) {
+                applyDiagnosticsToMessage(userMessage, []);
+            }
+        }
+
         if (result.success) {
-            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output);
-            
+            addMessage('assistant', result.output, result.usage_metadata, result.terminal_output, [], {
+                evaluation: result.evaluation_snapshot,
+                memory: result.memory_snapshot
+            });
+
+            if (currentProjectDir) {
+                setProjectMemoryState(
+                    currentProjectDir,
+                    result.memory_snapshot || {},
+                    result.evaluation_snapshot || {}
+                );
+            }
+
             if (result.project) {
                 currentProject = result.project;
                 if (result.ai_response_json) {
@@ -397,10 +805,10 @@ async function handleSubmit() {
     }
 }
 
-function addMessage(role, content, usageMetadata = null, terminalOutput = null) {
+function addMessage(role, content, usageMetadata = null, terminalOutput = null, attachments = [], metadata = {}) {
     const container = document.getElementById('resultsContainer');
-    if (!container) return;
-    
+    if (!container) return null;
+
     const message = document.createElement('div');
     message.className = `result-message ${role} selectable`;
 
@@ -424,21 +832,126 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
 
     message.appendChild(header);
     message.appendChild(messageContent);
-    
-    // ✅ Terminal輸出只顯示在用戶消息中
-    if (role === 'user' && terminalOutput && terminalOutput.trim()) {
+
+    if (attachments && attachments.length > 0) {
+        const attachmentsSection = document.createElement('div');
+        attachmentsSection.className = 'message-attachments';
+
+        attachments.forEach(file => {
+            if (!file || !file.name) return;
+            const chip = document.createElement('div');
+            chip.className = 'attachment-chip';
+
+            const iconEl = document.createElement('span');
+            iconEl.className = 'attachment-icon';
+            iconEl.textContent = '📎';
+
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'attachment-name';
+            nameSpan.textContent = file.name;
+            nameSpan.title = file.name;
+
+            const typeSpan = document.createElement('span');
+            typeSpan.className = 'attachment-type';
+            const typeLabelRaw = (file.type || '檔案').split('/')[0];
+            const typeLabel = typeLabelRaw ? typeLabelRaw.toUpperCase() : '檔案';
+            typeSpan.textContent = typeLabel;
+
+            chip.append(iconEl, nameSpan, typeSpan);
+            attachmentsSection.appendChild(chip);
+        });
+
+        message.appendChild(attachmentsSection);
+    }
+
+    if (metadata && metadata.memoryContext) {
+        const contextDetails = document.createElement('details');
+        contextDetails.className = 'memory-context-details';
+
+        const summaryEl = document.createElement('summary');
+        summaryEl.textContent = '已附加記憶上下文';
+
+        const contextText = document.createElement('pre');
+        contextText.className = 'memory-context-text selectable';
+        contextText.textContent = metadata.memoryContext;
+
+        contextDetails.append(summaryEl, contextText);
+        message.appendChild(contextDetails);
+    }
+
+    const diagnosticsHolder = document.createElement('div');
+    diagnosticsHolder.className = 'diagnostics-holder';
+    diagnosticsHolder.style.display = 'none';
+    message.appendChild(diagnosticsHolder);
+    messageDiagnosticsHolderMap.set(message, diagnosticsHolder);
+
+    if (metadata && metadata.evaluation) {
+        const evalData = metadata.evaluation;
+        const hasScore = Object.prototype.hasOwnProperty.call(evalData, '評分');
+        const hasSuggestion = Object.prototype.hasOwnProperty.call(evalData, '改進建議');
+
+        if (hasScore || hasSuggestion) {
+            const scoreText = hasScore && evalData['評分'] !== null && evalData['評分'] !== undefined
+                ? `${evalData['評分']} 分`
+                : '未提供';
+            const suggestionRaw = hasSuggestion ? evalData['改進建議'] : undefined;
+            const suggestionText = suggestionRaw === undefined || suggestionRaw === '' ? '暫無' : suggestionRaw;
+
+            const evaluationBox = document.createElement('div');
+            evaluationBox.className = 'message-evaluation-box';
+
+            const scoreRow = document.createElement('div');
+            scoreRow.className = 'evaluation-row';
+            const scoreLabel = document.createElement('span');
+            scoreLabel.className = 'evaluation-label';
+            scoreLabel.textContent = '評分';
+            const scoreValueEl = document.createElement('span');
+            scoreValueEl.className = 'evaluation-value';
+            scoreValueEl.textContent = scoreText;
+            scoreRow.append(scoreLabel, scoreValueEl);
+
+            const suggestionRow = document.createElement('div');
+            suggestionRow.className = 'evaluation-row';
+            const suggestionLabel = document.createElement('span');
+            suggestionLabel.className = 'evaluation-label';
+            suggestionLabel.textContent = '改進建議';
+            const suggestionValue = document.createElement('span');
+            suggestionValue.className = 'evaluation-value';
+            suggestionValue.textContent = suggestionText;
+            suggestionRow.append(suggestionLabel, suggestionValue);
+
+            evaluationBox.append(scoreRow, suggestionRow);
+            message.appendChild(evaluationBox);
+        }
+    }
+
+    if (metadata && metadata.memory) {
+        setProjectMemoryState(currentProjectDir, metadata.memory, metadata.evaluation || {});
+    }
+
+    if (metadata && Array.isArray(metadata.diagnosticsReport)) {
+        applyDiagnosticsToMessage(message, metadata.diagnosticsReport);
+    }
+
+    if (terminalOutput && terminalOutput.trim()) {
         const terminalSection = document.createElement('div');
         terminalSection.className = 'terminal-output-section';
-        terminalSection.innerHTML = `
-            <div class="terminal-header">
-                <span class="terminal-title">Terminal 輸出</span>
-            </div>
-            <div class="terminal-body selectable">${terminalOutput}</div>
-        `;
+
+        const terminalHeader = document.createElement('div');
+        terminalHeader.className = 'terminal-header';
+        const terminalTitle = document.createElement('span');
+        terminalTitle.className = 'terminal-title';
+        terminalTitle.textContent = 'Terminal 輸出';
+        terminalHeader.appendChild(terminalTitle);
+
+        const terminalBody = document.createElement('div');
+        terminalBody.className = 'terminal-body selectable';
+        terminalBody.textContent = terminalOutput;
+
+        terminalSection.append(terminalHeader, terminalBody);
         message.appendChild(terminalSection);
     }
-    
-    // Token使用統計只顯示在AI回應中
+
     if (role === 'assistant' && usageMetadata && typeof usageMetadata === 'object') {
         const tokenUsage = document.createElement('div');
         tokenUsage.className = 'token-usage';
@@ -462,9 +975,11 @@ function addMessage(role, content, usageMetadata = null, terminalOutput = null) 
         `;
         message.appendChild(tokenUsage);
     }
-    
+
     container.appendChild(message);
     message.scrollIntoView({ behavior: 'smooth' });
+
+    return message;
 }
 
 function useSuggestion(text) {
@@ -490,7 +1005,9 @@ async function createNewProject() {
         if (result.success && result.path) {
             currentProjectDir = result.path;
             isIterationMode = false;
-            
+
+            setProjectMemoryState(currentProjectDir, {}, {});
+
             document.getElementById('currentProjectDisplay').style.display = 'block';
             document.getElementById('currentProjectName').textContent = '新專案';
             const badge = document.getElementById('projectModeBadge');
@@ -654,7 +1171,10 @@ function getTimeAgo(dateString) {
 async function selectProject(project) {
     currentProjectDir = project.path;
     isIterationMode = true;
-    
+
+    renderMemoryPanel();
+    updateMemoryMenuHint();
+
     document.getElementById('currentProjectDisplay').style.display = 'block';
     document.getElementById('currentProjectName').textContent = project.name;
     const badge = document.getElementById('projectModeBadge');
@@ -717,11 +1237,46 @@ async function loadExistingProject(projectDir) {
                     container.innerHTML = '';
                     
                     for (const msg of result.conversation.messages) {
-                        addMessage(msg.role, msg.content, msg.usage_metadata, msg.terminal_output);
+                        const rawMetadata = msg.metadata || {};
+                        const normalizedMetadata = {
+                            ...rawMetadata
+                        };
+
+                        if (rawMetadata.evaluation_snapshot && !normalizedMetadata.evaluation) {
+                            normalizedMetadata.evaluation = rawMetadata.evaluation_snapshot;
+                        }
+                        if (rawMetadata.memory_snapshot && !normalizedMetadata.memory) {
+                            normalizedMetadata.memory = rawMetadata.memory_snapshot;
+                        }
+                        if (rawMetadata.memory_context && !normalizedMetadata.memoryContext) {
+                            normalizedMetadata.memoryContext = rawMetadata.memory_context;
+                        }
+                        if (rawMetadata.diagnostics_report && !normalizedMetadata.diagnosticsReport) {
+                            normalizedMetadata.diagnosticsReport = rawMetadata.diagnostics_report;
+                        }
+
+                        addMessage(
+                            msg.role,
+                            msg.content,
+                            msg.usage_metadata,
+                            msg.terminal_output,
+                            msg.files || [],
+                            normalizedMetadata
+                        );
                     }
                 }
             }
-            
+
+            if (result.conversation) {
+                setProjectMemoryState(
+                    projectDir,
+                    result.conversation.memory_snapshot || {},
+                    result.conversation.evaluation_snapshot || {}
+                );
+            } else {
+                setProjectMemoryState(projectDir, {}, {});
+            }
+
             return true;
         } else {
             return false;
@@ -831,14 +1386,16 @@ function resetToHome() {
     document.getElementById('resultsContainer').innerHTML = '';
     document.getElementById('projectStructureSection').style.display = 'none';
     document.getElementById('homeBtn').style.display = 'none';
-    
+
     document.querySelectorAll('.project-item').forEach(item => {
         item.classList.remove('active');
     });
-    
+
     updateFilesPreview();
     updateAttachedFilesDisplay();
-    
+    renderMemoryPanel();
+    updateMemoryMenuHint();
+
     showNotification('已回到初始介面', 'info');
 }
 

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -760,6 +760,13 @@ body {
     background: var(--bg-secondary);
 }
 
+.menu-hint {
+    font-size: 12px;
+    color: var(--text-secondary);
+    padding: 4px 6px 8px 6px;
+    line-height: 1.4;
+}
+
 .menu-divider {
     height: 1px;
     background: var(--border-light);
@@ -811,13 +818,265 @@ body {
 }
 
 /* =================================== */
-/* 結果容器 */
+/* 對話與記憶佈局 */
 /* =================================== */
-.results-container {
-    max-width: 900px;
+.conversation-layout {
+    display: flex;
+    gap: 20px;
     width: 100%;
-    margin: 0 auto;
+    align-items: stretch;
+}
+
+.results-container {
+    flex: 1;
+    max-width: 820px;
+    width: 100%;
+    margin: 0;
     padding: 20px;
+}
+
+.conversation-layout.memory-panel-collapsed .results-container {
+    max-width: 100%;
+}
+
+.conversation-layout.memory-panel-collapsed .memory-panel {
+    margin-left: auto;
+}
+
+.memory-panel {
+    width: 320px;
+    min-width: 320px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    border-radius: 12px;
+    box-shadow: var(--shadow-sm);
+    display: flex;
+    flex-direction: column;
+    position: sticky;
+    top: 90px;
+    max-height: calc(100vh - 140px);
+    overflow: hidden;
+    transition: box-shadow 0.2s ease, border-color 0.2s ease, width 0.3s ease, min-width 0.3s ease;
+}
+
+.memory-panel.collapsed {
+    border-color: var(--border-light);
+    width: 52px;
+    min-width: 52px;
+    overflow: visible;
+}
+
+.memory-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+    border-bottom: 1px solid var(--border-light);
+    background: var(--bg-primary);
+    gap: 12px;
+}
+
+.memory-title-group h3 {
+    font-size: 16px;
+    margin-bottom: 4px;
+}
+
+.memory-project-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.memory-score {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.memory-collapse-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    background: var(--bg-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.memory-collapse-btn:hover {
+    background: var(--bg-secondary);
+}
+
+.memory-collapse-btn.collapsed svg {
+    transform: rotate(180deg);
+}
+
+.memory-panel.collapsed .memory-panel-header {
+    flex-direction: column;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 8px;
+}
+
+.memory-panel.collapsed .memory-title-group,
+.memory-panel.collapsed .memory-header-actions .memory-score {
+    display: none;
+}
+
+.memory-panel-body {
+    padding: 16px 20px 20px 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    transition: opacity 0.3s ease;
+}
+
+.memory-panel.collapsed .memory-panel-body {
+    opacity: 0;
+    pointer-events: none;
+    padding: 0;
+}
+
+.memory-panel.collapsed .memory-panel-body::-webkit-scrollbar {
+    display: none;
+}
+
+.memory-section h4 {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+    letter-spacing: 0.4px;
+}
+
+.memory-text {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+}
+
+.memory-evaluation-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.memory-evaluation-item {
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-light);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.memory-eval-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.memory-eval-value {
+    font-size: 13px;
+    color: var(--text-primary);
+    line-height: 1.5;
+    white-space: pre-wrap;
+}
+
+.memory-placeholder {
+    font-size: 12px;
+    color: var(--text-tertiary);
+    padding: 10px 0;
+}
+
+.memory-bullet-list {
+    list-style: disc;
+    padding-left: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.memory-bullet-item {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-primary);
+}
+
+.memory-goals-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.memory-goal-item {
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: var(--bg-secondary);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.goal-step {
+    font-size: 12px;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.goal-current {
+    font-size: 10px;
+    color: #fff;
+    background: var(--primary-color);
+    border-radius: 999px;
+    padding: 2px 6px;
+}
+
+.goal-task {
+    font-size: 13px;
+    color: var(--text-primary);
+}
+
+.goal-status {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.goal-status.已完成 {
+    color: #16a34a;
+}
+
+.goal-status.進行中 {
+    color: #d97706;
+}
+
+.goal-status.未開始 {
+    color: #64748b;
+}
+
+@media (max-width: 1200px) {
+    .conversation-layout {
+        flex-direction: column;
+    }
+
+    .memory-panel {
+        position: static;
+        width: 100%;
+        max-height: none;
+    }
 }
 
 .result-message {
@@ -862,6 +1121,177 @@ body {
     color: var(--text-primary);
     white-space: pre-wrap;
     word-wrap: break-word;
+}
+
+.message-attachments {
+    margin-top: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.attachment-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.attachment-icon {
+    font-size: 14px;
+}
+
+.attachment-name {
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+}
+
+.attachment-type {
+    font-size: 10px;
+    color: var(--text-tertiary);
+}
+
+.memory-context-details {
+    margin-top: 10px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    padding: 8px 12px;
+    font-size: 13px;
+}
+
+.memory-context-details summary {
+    cursor: pointer;
+    color: var(--primary-color);
+    font-weight: 600;
+}
+
+.memory-context-details[open] summary {
+    margin-bottom: 6px;
+}
+
+.memory-context-text {
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+}
+
+.diagnostics-holder {
+    margin-top: 10px;
+}
+
+.diagnostics-details {
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    background: var(--bg-primary);
+    padding: 8px 12px;
+    font-size: 13px;
+}
+
+.diagnostics-details summary {
+    cursor: pointer;
+    color: var(--primary-color);
+    font-weight: 600;
+    outline: none;
+}
+
+.diagnostics-details[open] summary {
+    margin-bottom: 8px;
+}
+
+.diagnostics-empty {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.diagnostics-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.diagnostics-item {
+    display: flex;
+    gap: 10px;
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 8px 10px;
+    background: var(--bg-secondary);
+}
+
+.diagnostics-item[data-status="failed"] {
+    border-color: #f87171;
+    background: rgba(248, 113, 113, 0.12);
+}
+
+.diagnostics-item[data-status="warning"] {
+    border-color: #fbbf24;
+    background: rgba(251, 191, 36, 0.12);
+}
+
+.diagnostics-icon {
+    font-size: 18px;
+    line-height: 1;
+}
+
+.diagnostics-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.diagnostics-header {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 13px;
+}
+
+.diagnostics-message {
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    white-space: pre-wrap;
+}
+
+.message-evaluation-box {
+    margin-top: 10px;
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: var(--bg-primary);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.evaluation-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 12px;
+}
+
+.evaluation-label {
+    color: var(--text-secondary);
+}
+
+.evaluation-value {
+    color: var(--text-primary);
+    font-weight: 600;
+    text-align: right;
 }
 
 .token-usage {

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -1448,6 +1448,13 @@ body {
     border-color: var(--text-secondary);
 }
 
+.form-hint {
+    margin-top: 6px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text-secondary);
+}
+
 .password-input-group {
     position: relative;
 }

--- a/vscode_controller_project3-1/templates/index.html
+++ b/vscode_controller_project3-1/templates/index.html
@@ -179,7 +179,51 @@
                 </div>
             </div>
 
-            <div class="results-container" id="resultsContainer" style="display: none;"></div>
+            <div class="conversation-layout" id="conversationLayout">
+                <div class="results-container" id="resultsContainer" style="display: none;"></div>
+                <div class="memory-panel" id="memoryPanel" style="display: none;">
+                    <div class="memory-panel-header">
+                        <div class="memory-title-group">
+                            <h3>記憶與評分</h3>
+                            <span class="memory-project-label" id="memoryProjectLabel">尚未選擇專案</span>
+                        </div>
+                        <div class="memory-header-actions">
+                            <span class="memory-score" id="memoryScoreDisplay">--</span>
+                            <button class="memory-collapse-btn" id="memoryCollapseBtn" onclick="toggleMemoryPanel()" aria-label="收合記憶面板" aria-expanded="true">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <polyline points="9 6 15 12 9 18"/>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="memory-panel-body" id="memoryPanelBody">
+                        <section class="memory-section">
+                            <h4>品質評分</h4>
+                            <div class="memory-evaluation-list" id="memoryEvaluationList"></div>
+                        </section>
+                        <section class="memory-section">
+                            <h4>專案摘要</h4>
+                            <p class="memory-text" id="memorySummaryBox">尚未建立專案總結</p>
+                        </section>
+                        <section class="memory-section">
+                            <h4>短期記憶</h4>
+                            <ul class="memory-bullet-list" id="memorySTMList">
+                                <li class="memory-placeholder">尚未累積短期記憶</li>
+                            </ul>
+                        </section>
+                        <section class="memory-section">
+                            <h4>長期記憶</h4>
+                            <ul class="memory-bullet-list" id="memoryLTMList">
+                                <li class="memory-placeholder">尚未建立長期記憶</li>
+                            </ul>
+                        </section>
+                        <section class="memory-section">
+                            <h4>專案目標</h4>
+                            <div class="memory-goals-list" id="memoryGoalsList"></div>
+                        </section>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="input-area">
@@ -217,6 +261,21 @@
                                 </svg>
                                 <span>附加 Terminal 輸出</span>
                             </div>
+                            <div class="menu-item" id="diagnosticsMenuItem" onclick="toggleAttachDiagnostics()">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M9 9l6 6M15 9l-6 6"/>
+                                    <path d="M19 3H5a2 2 0 00-2 2v14l4-4h12a2 2 0 002-2V5a2 2 0 00-2-2z"/>
+                                </svg>
+                                <span>附加語法偵錯結果</span>
+                            </div>
+                            <div class="menu-item" id="memoryMenuItem" onclick="toggleAutoAttachMemory()">
+                                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 20l9-5-9-5-9 5 9 5z"/>
+                                    <path d="M3 10l9-5 9 5"/>
+                                </svg>
+                                <span>自動附加記憶上下文</span>
+                            </div>
+                            <div class="menu-hint" id="memorySuggestionPreview">上一輪改進建議：尚未有資料</div>
                             <div class="menu-divider"></div>
                             <div class="menu-item" onclick="showAdvancedSettings()">
                                 <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/vscode_controller_project3-1/templates/index.html
+++ b/vscode_controller_project3-1/templates/index.html
@@ -349,6 +349,15 @@
                     </select>
                 </div>
 
+                <div class="form-group">
+                    <label class="form-label">提示詞模式</label>
+                    <select class="form-select" id="promptMode">
+                        <option value="default">預設模式 (穩健執行)</option>
+                        <option value="creative">創意模式 (探索新功能)</option>
+                    </select>
+                    <div class="form-hint">預設模式優先確保需求完整與品質穩定；創意模式會額外鼓勵提出突破性的功能構想。</div>
+                </div>
+
                 <div class="info-box">
                     <strong id="modelInfoTitle">Gemini 2.5 Pro</strong><br>
                     <span id="modelInfoText">輸入上限: 1,048,576 tokens | 輸出上限: 65,535 tokens</span>


### PR DESCRIPTION
## Summary
- add DiagnosticsManager to collect multi-language syntax diagnostics and update the Gemini prompt to output list-based memories
- expose an optional syntax diagnostics toggle in the UI, render list-form short and long term memories, and shift the memory panel sideways when collapsed
- refresh memory panel and diagnostics styling to accommodate bullet lists and report details

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e8f567dfd08329a0150db63f7ffcdf