### PR TITLE
Improve project registration flow and existing folder handling

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -424,6 +424,123 @@ def sanitize_json_strings(data: Any) -> Any:
         return sanitized
 
     return data
+
+
+def _is_escaped(text: str, index: int) -> bool:
+    """判斷索引位置的字元是否被跳脫"""
+
+    backslash_count = 0
+    i = index - 1
+    while i >= 0 and text[i] == '\\':
+        backslash_count += 1
+        i -= 1
+    return backslash_count % 2 == 1
+
+
+def _reescape_string_literal_controls(code: str) -> str:
+    """將單行字串常值中的控制字元重新轉換為跳脫序列"""
+
+    if not code:
+        return code
+
+    result: List[str] = []
+    i = 0
+    length = len(code)
+    in_string = False
+    string_delim = ''
+    is_triple = False
+    in_comment = False
+
+    while i < length:
+        ch = code[i]
+
+        if in_comment:
+            result.append(ch)
+            if ch == '\n':
+                in_comment = False
+            i += 1
+            continue
+
+        if not in_string:
+            if ch == '#':
+                in_comment = True
+                result.append(ch)
+                i += 1
+                continue
+
+            if ch in ('"', "'"):
+                if code.startswith(ch * 3, i):
+                    string_delim = ch * 3
+                    is_triple = True
+                    in_string = True
+                    result.append(string_delim)
+                    i += 3
+                    continue
+                else:
+                    string_delim = ch
+                    is_triple = False
+                    in_string = True
+                    result.append(ch)
+                    i += 1
+                    continue
+
+            result.append(ch)
+            if ch == '\n':
+                in_comment = False
+            i += 1
+            continue
+
+        if is_triple:
+            if code.startswith(string_delim, i):
+                result.append(string_delim)
+                i += len(string_delim)
+                in_string = False
+                is_triple = False
+                string_delim = ''
+            else:
+                result.append(ch)
+                i += 1
+            continue
+
+        if ch in ('"', "'") and ch == string_delim and not _is_escaped(code, i):
+            result.append(ch)
+            i += 1
+            in_string = False
+            string_delim = ''
+            continue
+
+        if ch == '\n':
+            result.append('\\n')
+            i += 1
+            continue
+
+        if ch == '\r':
+            result.append('\\r')
+            i += 1
+            continue
+
+        if ch == '\t':
+            result.append('\\t')
+            i += 1
+            continue
+
+        result.append(ch)
+        i += 1
+
+    return ''.join(result)
+
+
+def normalize_code_content(code: str) -> str:
+    """恢復字串中的跳脫字元,並確保單行字串常值的控制字元重新跳脫"""
+
+    if not isinstance(code, str):
+        return code
+
+    normalized = code.replace('\\r\\n', '\n')
+    normalized = normalized.replace('\\n', '\n')
+    normalized = normalized.replace('\\t', '\t')
+
+    return _reescape_string_literal_controls(normalized)
 # ============================================
 # 配置管理模塊
 # ============================================
@@ -661,7 +778,7 @@ class ProjectManager:
         """載入專案所有檔案內容"""
         project_dir_path = Path(project_dir)
         files_data = []
-        
+
         exclude = {'PROJECT_INFO.json', '__pycache__', '.git', 'node_modules', 'venv', '.vscode'}
         
         for file_path in project_dir_path.rglob('*'):
@@ -682,15 +799,95 @@ class ProjectManager:
                     logger.info(f"已載入檔案: {rel_path}")
                 except Exception as e:
                     logger.warning(f"無法讀取檔案 {file_path}: {e}")
-        
+
         return files_data
-    
+
+    @staticmethod
+    def _infer_filetype(path: Path) -> str:
+        """根據副檔名推斷檔案類型"""
+        mapping = {
+            'py': 'python',
+            'js': 'javascript',
+            'ts': 'typescript',
+            'tsx': 'tsx',
+            'jsx': 'jsx',
+            'html': 'html',
+            'css': 'css',
+            'scss': 'scss',
+            'sass': 'sass',
+            'json': 'json',
+            'md': 'markdown',
+            'txt': 'text',
+            'yml': 'yaml',
+            'yaml': 'yaml',
+            'toml': 'toml',
+            'ini': 'ini',
+            'cfg': 'config',
+            'env': 'config',
+            'sh': 'shell',
+            'bat': 'batch',
+            'ps1': 'powershell',
+            'go': 'go',
+            'rs': 'rust',
+            'java': 'java',
+            'kt': 'kotlin',
+            'swift': 'swift',
+            'c': 'c',
+            'cpp': 'cpp',
+            'h': 'c-header',
+            'hpp': 'cpp-header',
+            'cs': 'csharp',
+            'php': 'php',
+            'rb': 'ruby',
+            'pl': 'perl',
+            'sql': 'sql',
+            'vue': 'vue',
+            'svelte': 'svelte',
+            'xml': 'xml',
+            'csv': 'csv',
+            'tsv': 'tsv',
+            'ipynb': 'notebook'
+        }
+
+        suffix = path.suffix.lower().lstrip('.')
+        if not suffix:
+            return 'text'
+        return mapping.get(suffix, suffix)
+
+    @staticmethod
+    def build_file_metadata(project_dir: str) -> List[Dict[str, Any]]:
+        """建立資料夾內檔案的基本描述列表"""
+        project_dir_path = Path(project_dir)
+        metadata: List[Dict[str, Any]] = []
+
+        if not project_dir_path.exists():
+            return metadata
+
+        exclude = {'PROJECT_INFO.json', '__pycache__', '.git', 'node_modules', 'venv', '.vscode'}
+
+        for file_path in project_dir_path.rglob('*'):
+            if not file_path.is_file():
+                continue
+
+            if file_path.name in exclude or any(ex in file_path.parts for ex in exclude):
+                continue
+
+            rel_path = file_path.relative_to(project_dir_path)
+            metadata.append({
+                'filename': str(rel_path),
+                'filetype': ProjectManager._infer_filetype(file_path),
+                'description': '現有檔案'
+            })
+
+        metadata.sort(key=lambda item: item['filename'].lower())
+        return metadata
+
     @staticmethod
     def get_project_structure(project_dir: str) -> str:
         """獲取專案結構字符串"""
         project_dir_path = Path(project_dir)
         structure_lines = [f"專案目錄: {project_dir_path.name}\n"]
-        
+
         exclude = {'PROJECT_INFO.json', '__pycache__', '.git', 'node_modules', 'venv', '.vscode'}
         
         def build_tree(directory, prefix=""):
@@ -711,41 +908,86 @@ class ProjectManager:
         return "\n".join(structure_lines)
     
     @staticmethod
-    def add_to_project_list(project_dir: str, project_name: str, description: str = ""):
+    def add_to_project_list(project_dir: str, project_name: str, description: str = "", status: str = 'ready'):
         """添加專案到列表"""
         try:
+            normalized_dir = str(Path(project_dir))
             project_list = ProjectManager.get_project_list()
-            
-            existing = next((p for p in project_list if p['path'] == project_dir), None)
-            
+
+            existing = next((p for p in project_list if p['path'] == normalized_dir), None)
+
             if existing:
                 existing['name'] = project_name
                 existing['description'] = description
                 existing['last_accessed'] = datetime.now().isoformat()
+                if status:
+                    existing['status'] = status
+                else:
+                    existing.pop('status', None)
             else:
-                project_list.append({
-                    'path': project_dir,
+                entry = {
+                    'path': normalized_dir,
                     'name': project_name,
                     'description': description,
                     'created_at': datetime.now().isoformat(),
                     'last_accessed': datetime.now().isoformat()
-                })
-            
+                }
+                if status:
+                    entry['status'] = status
+                project_list.append(entry)
+
             with open(PROJECT_LIST_FILE, 'w', encoding='utf-8') as f:
                 json.dump(project_list, f, indent=2, ensure_ascii=False)
-            
-            logger.info(f"已添加/更新專案到列表: {project_name}")
+
+            logger.info(f"已添加/更新專案到列表: {project_name} ({normalized_dir})")
             return True
         except Exception as e:
             logger.error(f"添加專案到列表失敗: {e}")
             return False
-    
+
+    @staticmethod
+    def ensure_placeholder_project(project_dir: str, project_name: Optional[str] = None, description: str = "") -> bool:
+        """確保新建專案在等待 AI 回應時也能出現在列表中"""
+        try:
+            normalized_dir = str(Path(project_dir))
+            display_name = project_name or Path(normalized_dir).name or '建立中專案'
+            placeholder_desc = description or '專案建立中，等待 AI 回應'
+
+            project_list = ProjectManager.get_project_list()
+            existing = next((p for p in project_list if p['path'] == normalized_dir), None)
+
+            timestamp = datetime.now().isoformat()
+
+            if existing:
+                existing['name'] = display_name
+                existing['description'] = placeholder_desc
+                existing['last_accessed'] = timestamp
+                existing['status'] = 'pending'
+            else:
+                project_list.append({
+                    'path': normalized_dir,
+                    'name': display_name,
+                    'description': placeholder_desc,
+                    'created_at': timestamp,
+                    'last_accessed': timestamp,
+                    'status': 'pending'
+                })
+
+            with open(PROJECT_LIST_FILE, 'w', encoding='utf-8') as f:
+                json.dump(project_list, f, indent=2, ensure_ascii=False)
+
+            logger.info(f"已建立專案佔位: {display_name} ({normalized_dir})")
+            return True
+        except Exception as e:
+            logger.error(f"建立專案佔位失敗: {e}")
+            return False
+
     @staticmethod
     def get_project_list() -> List[Dict]:
         """獲取專案列表"""
         if not PROJECT_LIST_FILE.exists():
             return []
-        
+
         try:
             with open(PROJECT_LIST_FILE, 'r', encoding='utf-8') as f:
                 return json.load(f)
@@ -757,13 +999,14 @@ class ProjectManager:
     def remove_from_project_list(project_dir: str):
         """從列表移除專案"""
         try:
+            normalized_dir = str(Path(project_dir))
             project_list = ProjectManager.get_project_list()
-            project_list = [p for p in project_list if p['path'] != project_dir]
-            
+            project_list = [p for p in project_list if p['path'] != normalized_dir]
+
             with open(PROJECT_LIST_FILE, 'w', encoding='utf-8') as f:
                 json.dump(project_list, f, indent=2, ensure_ascii=False)
-            
-            logger.info(f"已從列表移除專案: {project_dir}")
+
+            logger.info(f"已從列表移除專案: {normalized_dir}")
             return True
         except Exception as e:
             logger.error(f"移除專案失敗: {e}")
@@ -1435,10 +1678,7 @@ class CodeProcessor:
                 code = file_data.get('code', '')
 
                 if isinstance(code, str):
-                    code = code.replace('\\n', '\n')
-                    code = code.replace('\\t', '\t')
-                    code = code.replace('\\"', '"')
-                    code = code.replace("\\'", "'")
+                    code = normalize_code_content(code)
 
                 files.append(FileOutput(
                     filename=file_data.get('filename', 'untitled.txt'),
@@ -1976,10 +2216,17 @@ class ProcessManager:
         """執行完整的自動化流程 - 修復版"""
         
         result = ProcessResult(success=False, is_iteration=is_iteration)
-        
+
         try:
             files = list(files or [])
             user_files_snapshot = list(files)
+
+            normalized_folder = str(Path(folder_path))
+            if not is_iteration:
+                ProjectManager.ensure_placeholder_project(
+                    normalized_folder,
+                    Path(normalized_folder).name or '建立中專案'
+                )
 
             diagnostics_report: List[Dict[str, Any]] = []
             diagnostics_prompt_block = ''
@@ -2243,10 +2490,13 @@ class ProcessManager:
             window_titles_to_capture = []
             
             ProjectManager.add_to_project_list(final_project_dir, project.project_name, project.description)
-            
+
+            if not is_iteration and folder_path != final_project_dir:
+                ProjectManager.remove_from_project_list(folder_path)
+
             if project.main_file:
                 main_file_path = Path(final_project_dir) / project.main_file
-                
+
                 main_file_info = None
                 for file in project.files:
                     if file.filename == project.main_file:
@@ -2520,17 +2770,39 @@ def load_project():
                 'error': '專案目錄不存在'
             }), 400
         
+        project_dir_path = Path(project_dir)
         project_info = ProjectManager.load_project_info(project_dir)
-        if not project_info:
-            return jsonify({
-                'success': False,
-                'error': '找不到 PROJECT_INFO.json 檔案'
-            }), 404
-        
         project_files = ProjectManager.load_project_files(project_dir)
         project_structure = ProjectManager.get_project_structure(project_dir)
         conversation = ConversationManager.load_conversation(project_dir)
-        
+
+        is_ad_hoc_folder = False
+        if not project_info:
+            is_ad_hoc_folder = True
+            metadata_files = ProjectManager.build_file_metadata(project_dir)
+            project_info = {
+                'project_name': project_dir_path.name,
+                'description': '已匯入的現有資料夾',
+                'main_file': None,
+                'setup_instructions': [],
+                'run_instructions': [],
+                'files': metadata_files
+            }
+        else:
+            if not project_info.get('files'):
+                project_info['files'] = ProjectManager.build_file_metadata(project_dir)
+
+        if conversation.project_name != project_info.get('project_name'):
+            conversation.project_name = project_info.get('project_name', conversation.project_name)
+            ConversationManager.save_conversation(conversation)
+
+        ProjectManager.add_to_project_list(
+            project_dir,
+            project_info.get('project_name', project_dir_path.name),
+            project_info.get('description', ''),
+            status='ready'
+        )
+
         # ⭐ 修復:正確序列化對話消息,保留 usage_metadata
         messages_data = []
         for msg in conversation.messages:
@@ -2544,13 +2816,34 @@ def load_project():
                 'usage_metadata': msg.usage_metadata  # ⭐ 直接傳遞
             }
             messages_data.append(msg_dict)
-        
+
+        metadata_lookup = {}
+        for item in project_info.get('files', []) or []:
+            filename = item.get('filename')
+            if filename:
+                metadata_lookup[str(filename)] = item
+
+        auto_attach_preview = []
+        for file_data in project_files:
+            name = file_data.get('name')
+            if not name:
+                continue
+
+            meta = metadata_lookup.get(name, {})
+            preview_type = meta.get('filetype') or file_data.get('type', 'text/plain')
+            auto_attach_preview.append({
+                'name': name,
+                'type': preview_type
+            })
+
         return jsonify({
             'success': True,
             'project_info': project_info,
             'project_files': project_files,
             'project_structure': project_structure,
             'files_count': len(project_files),
+            'auto_attach_preview': auto_attach_preview,
+            'is_ad_hoc_folder': is_ad_hoc_folder,
             'conversation': {
                 'messages': messages_data,
                 'created_at': conversation.created_at,
@@ -2715,7 +3008,14 @@ def run_process():
                 'main_file': result.project_data.main_file,
                 'has_gui': any(f.opens_window for f in result.project_data.files)
             }
-        
+            response_data['auto_attach_preview'] = [
+                {
+                    'name': file.filename,
+                    'type': file.filetype or 'text'
+                }
+                for file in result.project_data.files
+            ]
+
         return jsonify(response_data)
         
     except Exception as e:

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -5,6 +5,7 @@
 // ============================================
 let currentProject = null;
 let uploadedFiles = [];
+let autoAttachedFiles = [];
 let isIterationMode = false;
 let currentProjectDir = null;
 let autoScreenshot = false;
@@ -100,6 +101,56 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 });
 
+function getFolderNameFromPath(path) {
+    if (!path) return '未命名專案';
+    const segments = path.split(/[\\/]+/).filter(Boolean);
+    if (segments.length === 0) return path;
+    return segments[segments.length - 1];
+}
+
+function upsertProjectListEntry(entry) {
+    if (!entry || !entry.path) return;
+
+    const now = new Date().toISOString();
+    entry.last_accessed = entry.last_accessed || now;
+
+    const existingIndex = allProjects.findIndex(project => project.path === entry.path);
+    if (existingIndex >= 0) {
+        allProjects[existingIndex] = { ...allProjects[existingIndex], ...entry };
+    } else {
+        allProjects.unshift({
+            created_at: now,
+            description: '',
+            status: 'ready',
+            ...entry
+        });
+    }
+
+    displayProjectsList(allProjects);
+}
+
+function registerPendingProject(userPrompt) {
+    if (!currentProjectDir) return;
+
+    const baseName = currentProject?.name || getFolderNameFromPath(currentProjectDir) || '新專案';
+    const description = isIterationMode
+        ? '延續既有專案'
+        : '專案建立中，等待 AI 回應';
+
+    const entry = {
+        path: currentProjectDir,
+        name: baseName,
+        description,
+        status: isIterationMode ? 'ready' : 'pending'
+    };
+
+    if (userPrompt && !isIterationMode) {
+        entry.description = `建立中：${userPrompt.slice(0, 30)}${userPrompt.length > 30 ? '…' : ''}`;
+    }
+
+    upsertProjectListEntry(entry);
+}
+
 // ============================================
 // 配置載入
 // ============================================
@@ -184,33 +235,92 @@ function removeFile(index) {
     showNotification('已移除檔案', 'info');
 }
 
+function setAutoAttachedFiles(files) {
+    autoAttachedFiles = (files || [])
+        .map(file => ({
+            name: file?.name || file?.filename,
+            type: (file?.type || file?.filetype || 'file').toLowerCase()
+        }))
+        .filter(file => !!file.name);
+    updateAttachedFilesDisplay();
+}
+
 function updateAttachedFilesDisplay() {
     const section = document.getElementById('attachedFilesSection');
     const countBadge = document.getElementById('attachedFilesCount');
-    const filesList = document.getElementById('attachedFilesList');
-    
-    if (!section || !countBadge || !filesList) return;
-    
-    if (uploadedFiles.length === 0) {
+    const manualList = document.getElementById('attachedFilesList');
+    const manualContainer = document.getElementById('manualAttachedFilesContainer');
+    const autoContainer = document.getElementById('autoAttachedFilesContainer');
+    const autoList = document.getElementById('autoAttachedFilesList');
+
+    if (!section || !countBadge || !manualList || !manualContainer || !autoContainer || !autoList) {
+        return;
+    }
+
+    const totalCount = uploadedFiles.length + autoAttachedFiles.length;
+
+    if (totalCount === 0) {
         section.style.display = 'none';
+        manualList.innerHTML = '';
+        autoList.innerHTML = '';
+        manualContainer.style.display = 'none';
+        autoContainer.style.display = 'none';
         updateProjectPanelVisibility();
         return;
     }
-    
+
     section.style.display = 'block';
-    countBadge.textContent = uploadedFiles.length;
-    filesList.innerHTML = '';
-    
-    uploadedFiles.forEach((file, index) => {
-        const fileItem = document.createElement('div');
-        fileItem.className = 'attached-file-item';
-        fileItem.innerHTML = `
-            <span class="attached-file-name">${file.name}</span>
-            <button class="remove-attached-btn" onclick="removeFile(${index})">×</button>
-        `;
-        filesList.appendChild(fileItem);
-    });
-    
+    countBadge.textContent = String(totalCount);
+
+    if (autoAttachedFiles.length > 0) {
+        autoContainer.style.display = 'block';
+        autoList.innerHTML = '';
+
+        autoAttachedFiles.forEach(file => {
+            if (!file || !file.name) return;
+
+            const fileItem = document.createElement('div');
+            fileItem.className = 'project-file-item attached-auto';
+
+            const badge = document.createElement('span');
+            badge.className = `file-type-badge ${file.type || 'text'}`;
+            badge.textContent = (file.type || 'FILE').toUpperCase();
+
+            const info = document.createElement('div');
+            info.style.flex = '1';
+            info.style.minWidth = '0';
+
+            const nameEl = document.createElement('div');
+            nameEl.className = 'file-name-text';
+            nameEl.textContent = file.name;
+            info.appendChild(nameEl);
+
+            fileItem.append(badge, info);
+            autoList.appendChild(fileItem);
+        });
+    } else {
+        autoContainer.style.display = 'none';
+        autoList.innerHTML = '';
+    }
+
+    if (uploadedFiles.length > 0) {
+        manualContainer.style.display = 'block';
+        manualList.innerHTML = '';
+
+        uploadedFiles.forEach((file, index) => {
+            const fileItem = document.createElement('div');
+            fileItem.className = 'attached-file-item';
+            fileItem.innerHTML = `
+                <span class="attached-file-name">${file.name}</span>
+                <button class="remove-attached-btn" onclick="removeFile(${index})">×</button>
+            `;
+            manualList.appendChild(fileItem);
+        });
+    } else {
+        manualContainer.style.display = 'none';
+        manualList.innerHTML = '';
+    }
+
     updateProjectPanelVisibility();
 }
 
@@ -250,9 +360,9 @@ function toggleProjectPanel() {
 
 function updateProjectPanelVisibility() {
     const hasProject = document.getElementById('projectStructureSection')?.style.display !== 'none';
-    const hasAttached = uploadedFiles.length > 0;
+    const hasAttached = uploadedFiles.length > 0 || autoAttachedFiles.length > 0;
     const emptyState = document.getElementById('panelEmptyState');
-    
+
     if (emptyState) {
         emptyState.style.display = (hasProject || hasAttached) ? 'none' : 'block';
     }
@@ -640,6 +750,29 @@ function handleKeyDown(event) {
     }
 }
 
+function showResultsPlaceholder(message) {
+    const container = document.getElementById('resultsContainer');
+    if (!container) return;
+
+    container.dataset.hasPlaceholder = 'true';
+    container.innerHTML = '';
+
+    const placeholder = document.createElement('div');
+    placeholder.className = 'results-placeholder';
+    placeholder.textContent = message;
+    container.appendChild(placeholder);
+}
+
+function clearResultsPlaceholder() {
+    const container = document.getElementById('resultsContainer');
+    if (!container) return;
+
+    if (container.dataset.hasPlaceholder === 'true') {
+        container.innerHTML = '';
+        delete container.dataset.hasPlaceholder;
+    }
+}
+
 // ============================================
 // 核心功能
 // ============================================
@@ -654,6 +787,8 @@ async function handleSubmit() {
         createNewProject();
         return;
     }
+
+    registerPendingProject(userPrompt);
 
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
@@ -723,6 +858,7 @@ async function handleSubmit() {
         userMetadata.memoryContext = memoryContextBlock;
     }
 
+    clearResultsPlaceholder();
     const userMessage = addMessage('user', userPrompt, null, null, attachmentsForMessage, userMetadata);
 
     input.value = '';
@@ -781,24 +917,37 @@ async function handleSubmit() {
                     currentProject.json_data = result.ai_response_json;
                     displayProjectStructure(result.ai_response_json.files);
                 }
-                
+
+                if (Array.isArray(result.auto_attach_preview)) {
+                    setAutoAttachedFiles(result.auto_attach_preview);
+                } else if (result.ai_response_json && Array.isArray(result.ai_response_json.files)) {
+                    setAutoAttachedFiles(result.ai_response_json.files.map(file => ({
+                        name: file.filename,
+                        type: file.filetype
+                    })));
+                }
+
                 document.getElementById('currentProjectName').textContent = currentProject.name;
-                
+
                 if (!isIterationMode) {
+                    const previousDir = currentProjectDir;
                     const newProjectDir = currentProjectDir + '/' + currentProject.name;
                     currentProjectDir = newProjectDir;
-                    
+
                     isIterationMode = true;
                     const badge = document.getElementById('projectModeBadge');
                     if (badge) {
                         badge.textContent = '延續';
                         badge.style.background = '#0ea5e9';
                     }
+
+                    allProjects = allProjects.filter(project => project.path !== previousDir);
+                    displayProjectsList(allProjects);
                 }
             }
 
             showNotification(result.is_iteration ? '專案迭代成功!' : '專案創建成功!', 'success');
-            
+
             loadProjectsList();
             uploadedFiles = [];
             updateFilesPreview();
@@ -818,6 +967,8 @@ async function handleSubmit() {
 function addMessage(role, content, usageMetadata = null, terminalOutput = null, attachments = [], metadata = {}) {
     const container = document.getElementById('resultsContainer');
     if (!container) return null;
+
+    clearResultsPlaceholder();
 
     const message = document.createElement('div');
     message.className = `result-message ${role} selectable`;
@@ -1034,13 +1185,13 @@ async function createNewProject() {
             
             uploadedFiles = [];
             updateFilesPreview();
-            updateAttachedFilesDisplay();
-            
+            setAutoAttachedFiles([]);
+
             document.getElementById('projectStructureSection').style.display = 'none';
             document.getElementById('emptyState').style.display = 'none';
             document.getElementById('resultsContainer').style.display = 'block';
-            document.getElementById('resultsContainer').innerHTML = '';
-            
+            showResultsPlaceholder('等待您的第一個指令…');
+
             showNotification('已選擇專案資料夾', 'success');
             document.getElementById('mainInput')?.focus();
         } else {
@@ -1065,8 +1216,8 @@ async function selectExistingFolder() {
             
             uploadedFiles = [];
             updateFilesPreview();
-            updateAttachedFilesDisplay();
-            
+            setAutoAttachedFiles([]);
+
             const loadResult = await loadExistingProject(result.path);
             
             if (loadResult) {
@@ -1142,23 +1293,37 @@ function displayProjectsList(projects) {
     projects.forEach(project => {
         const item = document.createElement('div');
         item.className = 'project-item';
-        
+
         if (currentProjectDir === project.path) {
             item.classList.add('active');
         }
-        
+
         const timeAgo = getTimeAgo(project.last_accessed);
-        
+        const statusBadge = project.status === 'pending'
+            ? '<span class="project-status pending">建立中</span>'
+            : (project.status && project.status !== 'ready'
+                ? `<span class="project-status">${project.status}</span>`
+                : '');
+
         item.innerHTML = `
             <div class="project-item-name">
                 <span>${project.name}</span>
-                <button class="delete-project-btn" onclick="event.stopPropagation(); deleteProject('${project.path.replace(/\\/g, '\\\\')}')">×</button>
+                ${statusBadge}
+                <button class="delete-project-btn">×</button>
             </div>
             <div class="project-item-desc">${project.description || '無描述'}</div>
             <div class="project-item-time">${timeAgo}</div>
         `;
-        
-        item.onclick = () => selectProject(project);
+
+        const deleteBtn = item.querySelector('.delete-project-btn');
+        if (deleteBtn) {
+            deleteBtn.addEventListener('click', (evt) => {
+                evt.stopPropagation();
+                deleteProject(project.path);
+            });
+        }
+
+        item.addEventListener('click', (evt) => selectProject(project, evt));
         container.appendChild(item);
     });
 }
@@ -1178,7 +1343,7 @@ function getTimeAgo(dateString) {
     return date.toLocaleDateString('zh-TW');
 }
 
-async function selectProject(project) {
+async function selectProject(project, evt) {
     currentProjectDir = project.path;
     isIterationMode = true;
 
@@ -1198,7 +1363,7 @@ async function selectProject(project) {
     document.querySelectorAll('.project-item').forEach(item => {
         item.classList.remove('active');
     });
-    event.target.closest('.project-item')?.classList.add('active');
+    evt?.currentTarget?.classList.add('active');
     
     document.getElementById('emptyState').style.display = 'none';
     document.getElementById('resultsContainer').style.display = 'block';
@@ -1206,10 +1371,10 @@ async function selectProject(project) {
     
     uploadedFiles = [];
     updateFilesPreview();
-    updateAttachedFilesDisplay();
+    setAutoAttachedFiles([]);
     
     await loadExistingProject(project.path);
-    
+
     showNotification(`已切換到專案: ${project.name}`, 'success');
 }
 
@@ -1237,10 +1402,18 @@ async function loadExistingProject(projectDir) {
                     main_file: result.project_info.main_file
                 }
             };
-            
+
             document.getElementById('currentProjectName').textContent = currentProject.name;
             displayProjectStructure(result.project_info.files);
-            
+            setAutoAttachedFiles(result.auto_attach_preview || []);
+
+            upsertProjectListEntry({
+                path: projectDir,
+                name: currentProject.name,
+                description: currentProject.description || '無描述',
+                status: 'ready'
+            });
+
             if (result.conversation && result.conversation.messages) {
                 const container = document.getElementById('resultsContainer');
                 if (container) {
@@ -1275,6 +1448,16 @@ async function loadExistingProject(projectDir) {
                         );
                     }
                 }
+            } else {
+                const container = document.getElementById('resultsContainer');
+                if (container) {
+                    showResultsPlaceholder('尚未有對話紀錄');
+                }
+            }
+
+            const container = document.getElementById('resultsContainer');
+            if (container && container.dataset.hasPlaceholder !== 'true' && container.children.length === 0) {
+                showResultsPlaceholder('尚未有對話紀錄');
             }
 
             if (result.conversation) {
@@ -1389,7 +1572,8 @@ function resetToHome() {
     currentProject = null;
     isIterationMode = false;
     uploadedFiles = [];
-    
+    autoAttachedFiles = [];
+
     document.getElementById('currentProjectDisplay').style.display = 'none';
     document.getElementById('emptyState').style.display = 'flex';
     document.getElementById('resultsContainer').style.display = 'none';
@@ -1402,7 +1586,7 @@ function resetToHome() {
     });
 
     updateFilesPreview();
-    updateAttachedFilesDisplay();
+    setAutoAttachedFiles([]);
     renderMemoryPanel();
     updateMemoryMenuHint();
 

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -233,7 +233,25 @@ body {
     margin-bottom: 4px;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: 8px;
+}
+
+.project-item-name .delete-project-btn {
+    margin-left: auto;
+}
+
+.project-status {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 6px;
+    border-radius: 6px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+}
+
+.project-status.pending {
+    background: rgba(16, 163, 127, 0.15);
+    color: var(--primary-color);
 }
 
 .project-item-desc {
@@ -520,6 +538,25 @@ body {
     background: var(--bg-secondary);
 }
 
+.panel-subsection {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--border-light);
+}
+
+.panel-subsection:last-of-type {
+    border-bottom: none;
+    padding-bottom: 8px;
+}
+
+.panel-subsection-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    padding: 0 18px 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
 .count-badge {
     background: var(--primary-color);
     color: white;
@@ -535,6 +572,10 @@ body {
     padding: 8px;
 }
 
+.panel-file-list.compact {
+    padding: 4px 12px;
+}
+
 .project-file-item,
 .attached-file-item {
     display: flex;
@@ -546,6 +587,11 @@ body {
     background: var(--bg-secondary);
     transition: all 0.2s;
     font-size: 13px;
+}
+
+.project-file-item.attached-auto {
+    border-left: 3px solid var(--primary-color);
+    background: rgba(16, 163, 127, 0.08);
 }
 
 .project-file-item:hover {
@@ -834,6 +880,18 @@ body {
     margin: 0;
     padding: 20px;
     min-height: 60vh; /* <-- 新增這一行 */
+}
+
+.results-placeholder {
+    width: 100%;
+    padding: 48px 32px;
+    border: 1px dashed var(--border-light);
+    border-radius: 12px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    text-align: center;
+    font-size: 15px;
+    line-height: 1.6;
 }
 
 .conversation-layout.memory-panel-collapsed .results-container {

--- a/vscode_controller_project3-1/templates/index.html
+++ b/vscode_controller_project3-1/templates/index.html
@@ -144,9 +144,16 @@
                             <span>附加檔案</span>
                             <span id="attachedFilesCount" class="count-badge">0</span>
                         </div>
-                        <div id="attachedFilesList" class="panel-file-list"></div>
+                        <div id="autoAttachedFilesContainer" class="panel-subsection" style="display: none;">
+                            <div class="panel-subsection-title">現有專案檔案 (自動附加)</div>
+                            <div id="autoAttachedFilesList" class="panel-file-list compact"></div>
+                        </div>
+                        <div id="manualAttachedFilesContainer" class="panel-subsection" style="display: none;">
+                            <div class="panel-subsection-title">手動附加檔案</div>
+                            <div id="attachedFilesList" class="panel-file-list"></div>
+                        </div>
                     </div>
-                    
+
                     <div id="panelEmptyState" class="panel-empty">
                         <svg class="icon-large" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/>


### PR DESCRIPTION
## Summary
- ensure backend registers placeholder projects, handles ad-hoc folders, and surfaces auto-attach previews for the UI
- add frontend project list updates, auto-attached file display, and results placeholders to smooth new/existing project transitions
- refine styles and layout so the memory panel and attachment sections stay consistent across project states

## Testing
- `python -m compileall app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ea12b0492083298b8986283336594d