### PR TITLE
Improve project onboarding and iteration UX

### DIFF
--- a/vscode_controller_project3-1/app.py
+++ b/vscode_controller_project3-1/app.py
@@ -424,6 +424,123 @@ def sanitize_json_strings(data: Any) -> Any:
         return sanitized
 
     return data
+
+
+def _is_escaped(text: str, index: int) -> bool:
+    """判斷索引位置的字元是否被跳脫"""
+
+    backslash_count = 0
+    i = index - 1
+    while i >= 0 and text[i] == '\\':
+        backslash_count += 1
+        i -= 1
+    return backslash_count % 2 == 1
+
+
+def _reescape_string_literal_controls(code: str) -> str:
+    """將單行字串常值中的控制字元重新轉換為跳脫序列"""
+
+    if not code:
+        return code
+
+    result: List[str] = []
+    i = 0
+    length = len(code)
+    in_string = False
+    string_delim = ''
+    is_triple = False
+    in_comment = False
+
+    while i < length:
+        ch = code[i]
+
+        if in_comment:
+            result.append(ch)
+            if ch == '\n':
+                in_comment = False
+            i += 1
+            continue
+
+        if not in_string:
+            if ch == '#':
+                in_comment = True
+                result.append(ch)
+                i += 1
+                continue
+
+            if ch in ('"', "'"):
+                if code.startswith(ch * 3, i):
+                    string_delim = ch * 3
+                    is_triple = True
+                    in_string = True
+                    result.append(string_delim)
+                    i += 3
+                    continue
+                else:
+                    string_delim = ch
+                    is_triple = False
+                    in_string = True
+                    result.append(ch)
+                    i += 1
+                    continue
+
+            result.append(ch)
+            if ch == '\n':
+                in_comment = False
+            i += 1
+            continue
+
+        if is_triple:
+            if code.startswith(string_delim, i):
+                result.append(string_delim)
+                i += len(string_delim)
+                in_string = False
+                is_triple = False
+                string_delim = ''
+            else:
+                result.append(ch)
+                i += 1
+            continue
+
+        if ch in ('"', "'") and ch == string_delim and not _is_escaped(code, i):
+            result.append(ch)
+            i += 1
+            in_string = False
+            string_delim = ''
+            continue
+
+        if ch == '\n':
+            result.append('\\n')
+            i += 1
+            continue
+
+        if ch == '\r':
+            result.append('\\r')
+            i += 1
+            continue
+
+        if ch == '\t':
+            result.append('\\t')
+            i += 1
+            continue
+
+        result.append(ch)
+        i += 1
+
+    return ''.join(result)
+
+
+def normalize_code_content(code: str) -> str:
+    """恢復字串中的跳脫字元,並確保單行字串常值的控制字元重新跳脫"""
+
+    if not isinstance(code, str):
+        return code
+
+    normalized = code.replace('\\r\\n', '\n')
+    normalized = normalized.replace('\\n', '\n')
+    normalized = normalized.replace('\\t', '\t')
+
+    return _reescape_string_literal_controls(normalized)
 # ============================================
 # 配置管理模塊
 # ============================================
@@ -690,47 +807,93 @@ class ProjectManager:
         """獲取專案結構字符串"""
         project_dir_path = Path(project_dir)
         structure_lines = [f"專案目錄: {project_dir_path.name}\n"]
-        
+
         exclude = {'PROJECT_INFO.json', '__pycache__', '.git', 'node_modules', 'venv', '.vscode'}
-        
+
         def build_tree(directory, prefix=""):
             contents = sorted(directory.iterdir(), key=lambda x: (x.is_file(), x.name))
             for i, path in enumerate(contents):
                 if path.name in exclude:
                     continue
-                
+
                 is_last = i == len(contents) - 1
                 current_prefix = "└── " if is_last else "├── "
                 structure_lines.append(f"{prefix}{current_prefix}{path.name}")
-                
+
                 if path.is_dir() and path.name not in exclude:
                     next_prefix = prefix + ("    " if is_last else "│   ")
                     build_tree(path, next_prefix)
-        
+
         build_tree(project_dir_path)
         return "\n".join(structure_lines)
+
+    @staticmethod
+    def _infer_filetype(path: Path) -> str:
+        ext = path.suffix.lower().lstrip('.')
+        if not ext:
+            return 'text'
+        if ext in {'py', 'js', 'ts', 'jsx', 'tsx', 'html', 'css', 'json', 'md', 'txt', 'csv', 'yml', 'yaml', 'toml', 'ini'}:
+            return ext
+        if ext in {'png', 'jpg', 'jpeg', 'gif', 'bmp', 'svg'}:
+            return 'image'
+        if ext in {'mp4', 'mov', 'avi'}:
+            return 'video'
+        if ext in {'mp3', 'wav', 'ogg'}:
+            return 'audio'
+        return ext
+
+    @staticmethod
+    def build_fallback_project_info(project_dir: str) -> Dict[str, Any]:
+        """為缺少 PROJECT_INFO 的資料夾建立基本資訊"""
+        project_dir_path = Path(project_dir)
+        exclude = {'PROJECT_INFO.json', '__pycache__', '.git', 'node_modules', 'venv', '.vscode'}
+
+        files_manifest = []
+        file_counter = 0
+        for file_path in project_dir_path.rglob('*'):
+            if file_path.is_file() and file_path.name not in exclude:
+                if any(ex in file_path.parts for ex in exclude):
+                    continue
+
+                files_manifest.append({
+                    'filename': str(file_path.relative_to(project_dir_path)),
+                    'filetype': ProjectManager._infer_filetype(file_path),
+                    'description': ''
+                })
+                file_counter += 1
+                if file_counter >= 500:
+                    break
+
+        return {
+            'project_name': project_dir_path.name,
+            'description': '匯入的現有資料夾',
+            'main_file': None,
+            'files': files_manifest
+        }
     
     @staticmethod
-    def add_to_project_list(project_dir: str, project_name: str, description: str = ""):
+    def add_to_project_list(project_dir: str, project_name: str, description: str = "", is_placeholder: bool = False):
         """添加專案到列表"""
         try:
             project_list = ProjectManager.get_project_list()
-            
+
             existing = next((p for p in project_list if p['path'] == project_dir), None)
-            
+
             if existing:
                 existing['name'] = project_name
                 existing['description'] = description
                 existing['last_accessed'] = datetime.now().isoformat()
+                existing['is_placeholder'] = is_placeholder
             else:
                 project_list.append({
                     'path': project_dir,
                     'name': project_name,
                     'description': description,
                     'created_at': datetime.now().isoformat(),
-                    'last_accessed': datetime.now().isoformat()
+                    'last_accessed': datetime.now().isoformat(),
+                    'is_placeholder': is_placeholder
                 })
-            
+
             with open(PROJECT_LIST_FILE, 'w', encoding='utf-8') as f:
                 json.dump(project_list, f, indent=2, ensure_ascii=False)
             
@@ -745,10 +908,14 @@ class ProjectManager:
         """獲取專案列表"""
         if not PROJECT_LIST_FILE.exists():
             return []
-        
+
         try:
             with open(PROJECT_LIST_FILE, 'r', encoding='utf-8') as f:
-                return json.load(f)
+                project_list = json.load(f)
+                for item in project_list:
+                    if 'is_placeholder' not in item:
+                        item['is_placeholder'] = False
+                return project_list
         except Exception as e:
             logger.error(f"讀取專案列表失敗: {e}")
             return []
@@ -1435,10 +1602,7 @@ class CodeProcessor:
                 code = file_data.get('code', '')
 
                 if isinstance(code, str):
-                    code = code.replace('\\n', '\n')
-                    code = code.replace('\\t', '\t')
-                    code = code.replace('\\"', '"')
-                    code = code.replace("\\'", "'")
+                    code = normalize_code_content(code)
 
                 files.append(FileOutput(
                     filename=file_data.get('filename', 'untitled.txt'),
@@ -2242,8 +2406,11 @@ class ProcessManager:
             execution_detail = ""
             window_titles_to_capture = []
             
-            ProjectManager.add_to_project_list(final_project_dir, project.project_name, project.description)
-            
+            ProjectManager.add_to_project_list(final_project_dir, project.project_name, project.description, is_placeholder=False)
+
+            if not is_iteration and final_project_dir != folder_path:
+                ProjectManager.remove_from_project_list(folder_path)
+
             if project.main_file:
                 main_file_path = Path(final_project_dir) / project.main_file
                 
@@ -2521,16 +2688,29 @@ def load_project():
             }), 400
         
         project_info = ProjectManager.load_project_info(project_dir)
+        info_source = 'project_info'
         if not project_info:
-            return jsonify({
-                'success': False,
-                'error': '找不到 PROJECT_INFO.json 檔案'
-            }), 404
-        
+            project_info = ProjectManager.build_fallback_project_info(project_dir)
+            info_source = 'fallback'
+
         project_files = ProjectManager.load_project_files(project_dir)
         project_structure = ProjectManager.get_project_structure(project_dir)
         conversation = ConversationManager.load_conversation(project_dir)
-        
+
+        if conversation.project_name != project_info.get('project_name'):
+            conversation.project_name = project_info.get('project_name', conversation.project_name)
+            ConversationManager.save_conversation(conversation)
+
+        attached_files_preview = []
+        for file_meta in project_info.get('files', []):
+            filename = file_meta.get('filename') or file_meta.get('name')
+            if not filename:
+                continue
+            attached_files_preview.append({
+                'name': filename,
+                'type': file_meta.get('filetype') or 'text'
+            })
+
         # ⭐ 修復:正確序列化對話消息,保留 usage_metadata
         messages_data = []
         for msg in conversation.messages:
@@ -2551,6 +2731,8 @@ def load_project():
             'project_files': project_files,
             'project_structure': project_structure,
             'files_count': len(project_files),
+            'attached_files': attached_files_preview,
+            'info_source': info_source,
             'conversation': {
                 'messages': messages_data,
                 'created_at': conversation.created_at,
@@ -2620,6 +2802,47 @@ def get_projects():
         })
     except Exception as e:
         logger.error(f"獲取專案列表失敗: {e}")
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+@app.route('/api/projects/register', methods=['POST'])
+def register_project():
+    """新增或更新專案列表中的專案條目"""
+    try:
+        data = request.get_json() or {}
+        project_path = data.get('path')
+
+        if not project_path:
+            return jsonify({
+                'success': False,
+                'error': '缺少專案路徑'
+            }), 400
+
+        project_name = data.get('name') or Path(project_path).name
+        description = data.get('description') or ''
+        is_placeholder = bool(data.get('is_placeholder', False))
+
+        success = ProjectManager.add_to_project_list(project_path, project_name, description, is_placeholder)
+
+        if success:
+            return jsonify({
+                'success': True,
+                'project': {
+                    'path': project_path,
+                    'name': project_name,
+                    'description': description,
+                    'is_placeholder': is_placeholder
+                }
+            })
+
+        return jsonify({
+            'success': False,
+            'error': '無法更新專案列表'
+        }), 500
+    except Exception as e:
+        logger.error(f"註冊專案失敗: {e}")
         return jsonify({
             'success': False,
             'error': str(e)

--- a/vscode_controller_project3-1/static/app.js
+++ b/vscode_controller_project3-1/static/app.js
@@ -5,6 +5,7 @@
 // ============================================
 let currentProject = null;
 let uploadedFiles = [];
+let autoAttachedFiles = [];
 let isIterationMode = false;
 let currentProjectDir = null;
 let autoScreenshot = false;
@@ -188,19 +189,42 @@ function updateAttachedFilesDisplay() {
     const section = document.getElementById('attachedFilesSection');
     const countBadge = document.getElementById('attachedFilesCount');
     const filesList = document.getElementById('attachedFilesList');
-    
+
     if (!section || !countBadge || !filesList) return;
-    
-    if (uploadedFiles.length === 0) {
+
+    if (uploadedFiles.length === 0 && autoAttachedFiles.length === 0) {
         section.style.display = 'none';
         updateProjectPanelVisibility();
         return;
     }
-    
+
     section.style.display = 'block';
-    countBadge.textContent = uploadedFiles.length;
+    countBadge.textContent = uploadedFiles.length + autoAttachedFiles.length;
     filesList.innerHTML = '';
-    
+
+    if (autoAttachedFiles.length > 0) {
+        autoAttachedFiles.forEach(file => {
+            if (!file || !file.name) return;
+            const autoItem = document.createElement('div');
+            autoItem.className = 'attached-file-item auto';
+
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'attached-file-name';
+            nameSpan.textContent = file.name;
+
+            const typeSpan = document.createElement('span');
+            typeSpan.className = 'auto-attachment-type';
+            typeSpan.textContent = (file.type || 'AUTO').toUpperCase();
+
+            const badge = document.createElement('span');
+            badge.className = 'auto-attachment-badge';
+            badge.textContent = '自動';
+
+            autoItem.append(nameSpan, typeSpan, badge);
+            filesList.appendChild(autoItem);
+        });
+    }
+
     uploadedFiles.forEach((file, index) => {
         const fileItem = document.createElement('div');
         fileItem.className = 'attached-file-item';
@@ -250,9 +274,9 @@ function toggleProjectPanel() {
 
 function updateProjectPanelVisibility() {
     const hasProject = document.getElementById('projectStructureSection')?.style.display !== 'none';
-    const hasAttached = uploadedFiles.length > 0;
+    const hasAttached = uploadedFiles.length > 0 || autoAttachedFiles.length > 0;
     const emptyState = document.getElementById('panelEmptyState');
-    
+
     if (emptyState) {
         emptyState.style.display = (hasProject || hasAttached) ? 'none' : 'block';
     }
@@ -780,10 +804,15 @@ async function handleSubmit() {
                 if (result.ai_response_json) {
                     currentProject.json_data = result.ai_response_json;
                     displayProjectStructure(result.ai_response_json.files);
+                    autoAttachedFiles = (result.ai_response_json.files || []).map(file => ({
+                        name: file.filename,
+                        type: file.filetype || 'text'
+                    }));
+                    updateAttachedFilesDisplay();
                 }
-                
+
                 document.getElementById('currentProjectName').textContent = currentProject.name;
-                
+
                 if (!isIterationMode) {
                     const newProjectDir = currentProjectDir + '/' + currentProject.name;
                     currentProjectDir = newProjectDir;
@@ -1006,6 +1035,39 @@ function useSuggestion(text) {
 // ============================================
 // 專案管理
 // ============================================
+function extractFolderName(fullPath) {
+    if (!fullPath) return '';
+    const normalized = fullPath.replace(/\\/g, '/').replace(/\/+$, '');
+    const parts = normalized.split('/');
+    return parts[parts.length - 1] || '';
+}
+
+async function registerProjectEntry(path, { name, description, isPlaceholder } = {}) {
+    if (!path) return;
+
+    const payload = {
+        path,
+        name,
+        description,
+        is_placeholder: isPlaceholder ?? false
+    };
+
+    try {
+        const response = await fetch('/api/projects/register', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+
+        const result = await response.json();
+        if (result.success) {
+            loadProjectsList();
+        }
+    } catch (error) {
+        console.warn('註冊專案失敗:', error);
+    }
+}
+
 async function createNewProject() {
     showLoading('正在開啟資料夾選擇器...');
     try {
@@ -1019,28 +1081,49 @@ async function createNewProject() {
             setProjectMemoryState(currentProjectDir, {}, {});
 
             document.getElementById('currentProjectDisplay').style.display = 'block';
-            document.getElementById('currentProjectName').textContent = '新專案';
+            const folderName = extractFolderName(result.path) || '新專案';
+            const placeholderName = `${folderName} (準備中)`;
+            document.getElementById('currentProjectName').textContent = placeholderName;
             const badge = document.getElementById('projectModeBadge');
             if (badge) {
                 badge.textContent = '新建';
                 badge.style.background = '#10a37f';
             }
-            
+
             document.getElementById('homeBtn').style.display = 'flex';
-            
+
             document.querySelectorAll('.project-item').forEach(item => {
                 item.classList.remove('active');
             });
-            
+
             uploadedFiles = [];
+            autoAttachedFiles = [];
             updateFilesPreview();
             updateAttachedFilesDisplay();
-            
+
             document.getElementById('projectStructureSection').style.display = 'none';
             document.getElementById('emptyState').style.display = 'none';
             document.getElementById('resultsContainer').style.display = 'block';
             document.getElementById('resultsContainer').innerHTML = '';
-            
+
+            currentProject = {
+                name: placeholderName,
+                description: 'AI 正在建立專案，暫存對話已啟動。',
+                files_count: 0,
+                main_file: null
+            };
+            renderMemoryPanel();
+            updateMemoryMenuHint();
+
+            const layout = document.getElementById('conversationLayout');
+            layout?.classList.remove('memory-panel-collapsed');
+
+            registerProjectEntry(currentProjectDir, {
+                name: placeholderName,
+                description: 'AI 正在建立專案，暫存條目供快速返回。',
+                isPlaceholder: true
+            });
+
             showNotification('已選擇專案資料夾', 'success');
             document.getElementById('mainInput')?.focus();
         } else {
@@ -1068,7 +1151,7 @@ async function selectExistingFolder() {
             updateAttachedFilesDisplay();
             
             const loadResult = await loadExistingProject(result.path);
-            
+
             if (loadResult) {
                 document.getElementById('currentProjectDisplay').style.display = 'block';
                 document.getElementById('currentProjectName').textContent = currentProject.name;
@@ -1086,7 +1169,7 @@ async function selectExistingFolder() {
                 
                 document.getElementById('emptyState').style.display = 'none';
                 document.getElementById('resultsContainer').style.display = 'block';
-                
+
                 showNotification(`已載入專案: ${currentProject.name}`, 'success');
             } else {
                 showNotification('此資料夾不是有效的專案，將作為新專案', 'warning');
@@ -1142,22 +1225,61 @@ function displayProjectsList(projects) {
     projects.forEach(project => {
         const item = document.createElement('div');
         item.className = 'project-item';
-        
+
         if (currentProjectDir === project.path) {
             item.classList.add('active');
         }
-        
+
+        if (project.is_placeholder) {
+            item.classList.add('placeholder');
+        }
+
         const timeAgo = getTimeAgo(project.last_accessed);
-        
-        item.innerHTML = `
-            <div class="project-item-name">
-                <span>${project.name}</span>
-                <button class="delete-project-btn" onclick="event.stopPropagation(); deleteProject('${project.path.replace(/\\/g, '\\\\')}')">×</button>
-            </div>
-            <div class="project-item-desc">${project.description || '無描述'}</div>
-            <div class="project-item-time">${timeAgo}</div>
-        `;
-        
+
+        const nameRow = document.createElement('div');
+        nameRow.className = 'project-item-name';
+
+        const titleSpan = document.createElement('span');
+        titleSpan.className = 'project-item-title';
+        titleSpan.textContent = project.name;
+
+        if (project.is_placeholder) {
+            titleSpan.appendChild(document.createTextNode(' '));
+            const statusBadge = document.createElement('span');
+            statusBadge.className = 'project-status-badge';
+            statusBadge.textContent = '暫存';
+            titleSpan.appendChild(statusBadge);
+        }
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'delete-project-btn';
+        deleteBtn.textContent = '×';
+        deleteBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            deleteProject(project.path);
+        });
+
+        nameRow.appendChild(titleSpan);
+        nameRow.appendChild(deleteBtn);
+
+        const descRow = document.createElement('div');
+        descRow.className = 'project-item-desc';
+        if (project.description) {
+            descRow.textContent = project.description;
+        } else if (project.is_placeholder) {
+            descRow.textContent = 'AI 建立中，等待回應...';
+        } else {
+            descRow.textContent = '無描述';
+        }
+
+        const timeRow = document.createElement('div');
+        timeRow.className = 'project-item-time';
+        timeRow.textContent = timeAgo;
+
+        item.appendChild(nameRow);
+        item.appendChild(descRow);
+        item.appendChild(timeRow);
+
         item.onclick = () => selectProject(project);
         container.appendChild(item);
     });
@@ -1225,22 +1347,48 @@ async function loadExistingProject(projectDir) {
         const result = await response.json();
         
         if (result.success) {
+            const existingEntry = allProjects.find(p => p.path === projectDir);
+            const infoSource = result.info_source || 'project_info';
+
+            let descriptionText = result.project_info.description || '';
+            if (infoSource === 'fallback') {
+                descriptionText = existingEntry?.description || descriptionText;
+            } else if (!descriptionText) {
+                descriptionText = existingEntry?.description || '';
+            }
+
+            const actualProjectName = result.project_info.project_name;
+            const displayName = (existingEntry?.is_placeholder && infoSource === 'fallback')
+                ? (existingEntry.name || actualProjectName)
+                : actualProjectName;
+
             currentProject = {
-                name: result.project_info.project_name,
-                description: result.project_info.description,
+                name: displayName,
+                description: descriptionText,
                 files_count: result.files_count,
                 main_file: result.project_info.main_file,
                 json_data: {
-                    project_name: result.project_info.project_name,
-                    description: result.project_info.description,
+                    project_name: actualProjectName,
+                    description: descriptionText,
                     files: result.project_info.files,
                     main_file: result.project_info.main_file
                 }
             };
-            
-            document.getElementById('currentProjectName').textContent = currentProject.name;
+            registerProjectEntry(projectDir, {
+                name: displayName,
+                description: currentProject.description || '匯入的現有資料夾',
+                isPlaceholder: existingEntry?.is_placeholder ?? false
+            });
+
+            document.getElementById('currentProjectName').textContent = displayName;
             displayProjectStructure(result.project_info.files);
-            
+
+            autoAttachedFiles = (result.attached_files || []).map(file => ({
+                name: file.name,
+                type: file.type
+            }));
+            updateAttachedFilesDisplay();
+
             if (result.conversation && result.conversation.messages) {
                 const container = document.getElementById('resultsContainer');
                 if (container) {
@@ -1389,7 +1537,8 @@ function resetToHome() {
     currentProject = null;
     isIterationMode = false;
     uploadedFiles = [];
-    
+    autoAttachedFiles = [];
+
     document.getElementById('currentProjectDisplay').style.display = 'none';
     document.getElementById('emptyState').style.display = 'flex';
     document.getElementById('resultsContainer').style.display = 'none';

--- a/vscode_controller_project3-1/static/styles.css
+++ b/vscode_controller_project3-1/static/styles.css
@@ -218,12 +218,31 @@ body {
     background: transparent;
 }
 
+.project-item.placeholder {
+    background: rgba(16, 163, 127, 0.08);
+}
+
 .project-item:hover {
     background: var(--bg-primary);
 }
 
 .project-item.active {
     background: var(--bg-primary);
+}
+
+.project-item-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.project-status-badge {
+    font-size: 11px;
+    font-weight: 600;
+    color: #92400e;
+    background: #fef3c7;
+    border-radius: 999px;
+    padding: 1px 8px;
 }
 
 .project-item-name {
@@ -556,6 +575,12 @@ body {
     border: 1px solid var(--border-light);
 }
 
+.attached-file-item.auto {
+    border-style: dashed;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+}
+
 .file-type-badge {
     font-size: 9px;
     padding: 3px 6px;
@@ -573,6 +598,21 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.auto-attachment-type {
+    font-size: 11px;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+}
+
+.auto-attachment-badge {
+    font-size: 11px;
+    font-weight: 600;
+    color: #1d4ed8;
+    background: #dbeafe;
+    border-radius: 999px;
+    padding: 1px 8px;
 }
 
 .file-desc-text {


### PR DESCRIPTION
## Summary
- add backend support for placeholder project entries, fallback project info, and attached file previews when loading existing folders
- update the frontend to register new and existing projects immediately, surface auto-attached files, and keep memory panel layout consistent during onboarding
- style the project list and attachment panel to highlight placeholders and auto-attached context

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ea12b0492083298b8986283336594d